### PR TITLE
PCC-61: Update Content API query.

### DIFF
--- a/src/api/ContentApi.php
+++ b/src/api/ContentApi.php
@@ -20,9 +20,13 @@ class ContentApi extends PccApi {
   public function getAllArticles(): mixed {
     $query = <<<'GRAPHQL'
     query{
-      articles {
+      articles(contentType: TREE_PANTHEON_V2) {
         id
         title
+        content
+        snippet
+        publishedDate
+        updatedAt
       }
     }
     GRAPHQL;


### PR DESCRIPTION
Update query to include  following:

        content
        snippet
        publishedDate
        updatedAt

And use contentType: TREE_PANTHEON_V2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced article fetching to include specific content types and additional fields like content, snippet, published date, and updated date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->