### PR TITLE
PCC-77: Implements google doc markdown to html parser.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "guzzlehttp/guzzle": "^7.8",
     "guzzlehttp/psr7": "^2.6",
     "guzzlehttp/promises": "^2.0",
-    "cfpinto/graphql": "v2.0.0"
+    "cfpinto/graphql": "v2.0.0",
+    "erusev/parsedown": "^1.7"
   },
   "autoload": {
     "psr-4": {

--- a/src/api/Query/ArticleQueryArgs.php
+++ b/src/api/Query/ArticleQueryArgs.php
@@ -69,7 +69,7 @@ class ArticleQueryArgs {
     ArticleSortOrder $sortOrder = ArticleSortOrder::DESC,
     int $pageSize = 10,
     int $pageIndex = 1,
-    ContentType $contentType = ContentType::TREE_PANTHEON_V2
+    ContentType $contentType = ContentType::TEXT_MARKDOWN,
   ) {
     $this->contentType = $contentType;
     $this->sortField = $sortField;

--- a/src/api/Query/README.md
+++ b/src/api/Query/README.md
@@ -51,7 +51,7 @@ $queryArgs = new ArticleQueryArgs(
     ArticleSortOrder::DESC,
     20,
     1,
-    ContentType::TREE_PANTHEON_V2
+    ContentType::TEXT_MARKDOWN
 );
 
 $paginatedArticles = $articlesApi->searchArticles($queryArgs);
@@ -100,7 +100,7 @@ $queryArgs = new ArticleQueryArgs(
     ArticleSortOrder::DESC,
     20,
     1,
-    ContentType::TREE_PANTHEON_V2
+    ContentType::TEXT_MARKDOWN
 );
 $searchArgs = new ArticleSearchArgs(
     'example body',

--- a/src/core/Entity/Loader/ArticleLoader.php
+++ b/src/core/Entity/Loader/ArticleLoader.php
@@ -146,11 +146,33 @@ class ArticleLoader implements ArticleLoaderInterface {
           $article->{$field} = $data[$field] ?: [];
           break;
 
+        case 'content':
+        case 'snippet':
+          $article->{$field} = $data[$field] ? $this->parseMarkdownToHtml($data[$field]) : '';
+          break;
+
         default:
           $article->{$field} = $data[$field] ?? '';
       }
     }
     return $article;
+  }
+
+  /**
+   * Convert markdown format to html.
+   *
+   * @param string $content
+   *   The markdown string.
+   *
+   * @return string
+   *   Returns the html string.
+   */
+  private function parseMarkdownToHtml(string $content): string {
+    // Replace all occurrences of the pattern `{#h\..*}\n` with `\n`.
+    $pattern = '/{#h\..*}\n/';
+    $content = preg_replace($pattern, "\n", $content);
+    $parsedown = new \Parsedown();
+    return $parsedown->text($content);
   }
 
   /**

--- a/src/core/Query/Builder/Article/ArticleQueryBuilder.php
+++ b/src/core/Query/Builder/Article/ArticleQueryBuilder.php
@@ -2,7 +2,6 @@
 
 namespace PccPhpSdk\core\Query\Builder\Article;
 
-use ArrayObject;
 use GraphQL\Actions\Query;
 use GraphQL\Entities\Variable;
 use PccPhpSdk\api\Query\Enums\ContentType;
@@ -15,20 +14,19 @@ use PccPhpSdk\core\Query\QueryInterface;
  * Article Query Builder to get single Article.
  */
 class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
-
   /**
    * Article ID to filter.
    *
-   * @var string|null $id
+   * @var string|null
    */
-  private ?string $id = null;
+  private ?string $id = NULL;
 
   /**
    * Article Slug to filter.
    *
-   * @var string|null $slug
+   * @var string|null
    */
-  private ?string $slug = null;
+  private ?string $slug = NULL;
 
   /**
    * Add ID for filter in the query.
@@ -36,7 +34,7 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @param string $id
    *   ID value.
    *
-   * @return QueryBuilderInterface
+   * @return \GraphQL\Actions\QueryBuilderInterface
    *   Returns self.
    */
   public function filterById(string $id): QueryBuilderInterface {
@@ -50,9 +48,9 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * If ID filter already present, that will take precedence.
    *
    * @param string $slug
-   *    Slug Value.
+   *   Slug Value.
    *
-   * @return QueryBuilderInterface
+   * @return \GraphQL\Actions\QueryBuilderInterface
    *   Returns self.
    */
   public function filterBySlug(string $slug): QueryBuilderInterface {
@@ -78,47 +76,48 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    *   Returns Query Args.
    */
   private function getQueryArgs(): array {
+    $content_type = ContentType::TEXT_MARKDOWN->value;
     $args = [
-      'contentType' => ContentType::TREE_PANTHEON_V2,
+      Variables::CONTENT_TYPE => Variables::getVariableDefinition(Variables::CONTENT_TYPE, $content_type),
     ];
+
     $variable = $this->getVariableDef();
     if (!empty($variable)) {
       $args = array_merge($args, $variable);
     }
-
     return $args;
   }
 
   /**
    * Get Variable value.
    *
-   * @return ArrayObject
+   * @return \ArrayObject
    *   Returns Variable mapped values.
    */
-  private function getVariableVal(): ArrayObject {
+  private function getVariableVal(): \ArrayObject {
     $value = [];
-    if ($this->id !== null) {
+    if ($this->id !== NULL) {
       $value[ArticleLoaderInterface::ID] = $this->id;
     }
-    elseif ($this->slug !== null) {
+    elseif ($this->slug !== NULL) {
       $value[ArticleLoaderInterface::SLUG] = $this->slug;
     }
 
-    return new ArrayObject($value);
+    return new \ArrayObject($value);
   }
 
   /**
-   * Get Variable Definition for GraphQL\Actions\Query
+   * Get Variable Definition for GraphQL\Actions\Query.
    *
-   * @return Variable[]|null
+   * @return \GraphQL\Entities\Variable[]|null
    *   Return ID or Slug variable definition or null.
    */
   private function getVariableDef(): ?array {
-    $variable = null;
-    if ($this->id !== null) {
+    $variable = NULL;
+    if ($this->id !== NULL) {
       $variable = [ArticleLoaderInterface::ID => $this->buildIdVariableDef()];
     }
-    else if ($this->slug !== null) {
+    elseif ($this->slug !== NULL) {
       $variable = [ArticleLoaderInterface::SLUG => $this->buildSlugVariableDef()];
     }
 
@@ -128,7 +127,7 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
   /**
    * Build ID Variable Definition for the GraphQL\Actions\Query.
    *
-   * @return Variable
+   * @return \GraphQL\Entities\Variable
    *   Return Variable Definition.
    */
   private function buildIdVariableDef(): Variable {
@@ -138,10 +137,11 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
   /**
    * Build ID Variable Definition for the GraphQL\Actions\Query.
    *
-   * @return Variable
+   * @return \GraphQL\Entities\Variable
    *   Return Variable Definition.
    */
   private function buildSlugVariableDef(): Variable {
     return new Variable(ArticleLoaderInterface::SLUG, 'String');
   }
+
 }

--- a/src/core/Query/Builder/Article/ArticlesListQueryBuilder.php
+++ b/src/core/Query/Builder/Article/ArticlesListQueryBuilder.php
@@ -58,7 +58,7 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    *
    * @var ContentType
    */
-  private ContentType $contentType = ContentType::TREE_PANTHEON_V2;
+  private ContentType $contentType = ContentType::TEXT_MARKDOWN;
 
   /**
    * Build the GraphQL query.

--- a/src/core/Query/Builder/Article/Variables.php
+++ b/src/core/Query/Builder/Article/Variables.php
@@ -5,7 +5,7 @@ namespace PccPhpSdk\core\Query\Builder\Article;
 use GraphQL\Entities\Variable;
 
 /**
- * Class Variables
+ * Class Variables.
  *
  * Defines constants and methods to handle variable definitions for GraphQL queries.
  */
@@ -23,11 +23,13 @@ class Variables {
    *
    * @param string $fieldName
    *   The field name for which the variable definition is needed.
+   * @param string $defaultValue
+   *   The default value for field.
    *
-   * @return Variable|null
+   * @return \GraphQL\Entities\Variable|null
    *   Returns the variable definition or null if the field name is invalid.
    */
-  public static function getVariableDefinition(string $fieldName): ?Variable {
+  public static function getVariableDefinition(string $fieldName, string $defaultValue = ''): ?Variable {
     switch ($fieldName) {
       case self::FILTER:
         return new Variable(self::FILTER, 'ArticleFilterInput');
@@ -45,10 +47,11 @@ class Variables {
         return new Variable(self::PAGE_INDEX, 'Float');
 
       case self::CONTENT_TYPE:
-        return new Variable(self::CONTENT_TYPE, 'ContentType');
+        return new Variable(self::CONTENT_TYPE, 'ContentType', $defaultValue);
 
       default:
-        return null;
+        return NULL;
     }
   }
+
 }


### PR DESCRIPTION
## Ticket
- https://digitalpolygon.atlassian.net/browse/PCC-77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new dependency `"erusev/parsedown": "^1.7"` to the project.
  - Implemented logic for parsing markdown content to HTML in the `ArticleLoader.php`.
  - Updated the `contentType` property value in `ArticlesListQueryBuilder` from `TREE_PANTHEON_V2` to `TEXT_MARKDOWN`.
  - Enhanced flexibility of variable definitions for GraphQL queries by updating the `getVariableDefinition` method in the `Variables` class.

- **Refactor**
  - Updated default value in `ArticleQueryArgs.php` and `README.md` from `TREE_PANTHEON_V2` to `TEXT_MARKDOWN`.
  - Modified method signatures and variable assignments in `ArticleQueryBuilder.php`.
  - Adjusted return types in `ArticleQueryBuilder.php` and `ArticleQueryBuilder.php`.
  - Altered return types in `ArticleQueryBuilder.php` to return `\GraphQL\Entities\Variable`.

- **Documentation**
  - Added method documentation for `parseMarkdownToHtml` in `ArticleLoader.php`.
  - Updated `getVariableDefinition` method in `Variables.php` to accept a default value parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->