### PR TITLE
Update composer.json to remove reference to DP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "digitalpolygon/pcc-php-sdk",
+  "name": "pantheon-systems/pcc-php-sdk",
   "description": "SDK Library for PCC Integration.",
   "type": "library",
-  "homepage": "https://github.com/digitalpolygon/pcc-php-sdk/",
+  "homepage": "https://github.com/pantheon-systems/pcc-php-sdk/",
   "require": {
     "php": ">=8",
     "guzzlehttp/guzzle": "^7.8",


### PR DESCRIPTION
1. Removes the references to DigitalPolygon from composer.json

Note: Once this PR is merged, you will need to update your existing Composer-based installation to point to the new Composer package name.

```
digitalpolygon/pcc-php-sdk => pantheon-systems/pcc-php-sdk
```