### PR TITLE
[SITE-4824] Update SDK for Wordpress Validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,27 @@
   "homepage": "https://github.com/pantheon-systems/pcc-php-sdk/",
   "require": {
     "php": ">=8",
-    "guzzlehttp/guzzle": "^7.8",
-    "guzzlehttp/psr7": "^2.6",
-    "guzzlehttp/promises": "^2.0",
-    "cfpinto/graphql": "v2.0.0",
+    "guzzlehttp/guzzle": "^7.9.3",
+    "guzzlehttp/psr7": "^2.7.1",
+    "guzzlehttp/promises": "^2.2.0",
+    "cfpinto/graphql": "v2.0.1",
     "erusev/parsedown": "^1.7"
   },
   "autoload": {
     "psr-4": {
       "PccPhpSdk\\": "src/"
+    }
+  },
+  "require-dev": {
+    "phpcompatibility/php-compatibility": "^9.3"
+  },
+  "scripts": {
+    "lint": "vendor/bin/phpcs --standard=phpcs.xml --extensions=php --report=full",
+    "phpcomp": "vendor/bin/phpcs --standard=phpcs-comp.xml --report=source"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }


### PR DESCRIPTION
In May 2024, WordPress declined the submission of plugin [Pantheon Content Publisher ](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress) with note:

"_At least one of the 3rd party libraries you're using is out of date. Please upgrade to the latest stable version for better support and security. We do not recommend you use beta releases._
`pantheon-systems/pcc-php-sdk dev-main 695c7c3 ! dev-main 8d2ea5f SDK Library for PCC Integrat...` "

- Updates libraries' versions 
- Create a stable tag 1.0.0