### PR TITLE
[PCC 2255] Add support for draft publishing level and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@
 ```
 
 ## Getting all articles
+
 ```php
     $articlesApi = new \PccPhpSdk\api\ArticlesApi($pccClient);
     $fields = ['id', 'snippet', 'slug', 'title'];
     $articles = $articlesApi->getAllArticles($fields);
 ```
+
 Here `$fields` is optional. If we do not pass `$fields` to get the selective fields, then it will return default fields in the resposnse.
 
 We receive response as object of PccPhpSdk\api\Response\PaginatedArticles which can be used further.
@@ -38,6 +40,7 @@ $searchArgs = new ArticleSearchArgs(
 $fields = ['id', 'snippet', 'slug', 'title'];
 $paginatedArticles = $articlesApi->getAllArticles(new ArticleQueryArgs(), $searchArgs, $fields);
 ```
+
 Here `$fields` is optional. If we do not pass `$fields` to get the selective fields, then it will return default fields in the resposnse.
 
 Here also we receive response as object of PccPhpSdk\api\Response\PaginatedArticles which can be used further.
@@ -55,6 +58,7 @@ $article1 = $articlesApi->getArticleById($id, $fields);
 $slug = 'slug-goes-here';
 $article2 = $articlesApi->getArticleBySlug($slug, $fields);
 ```
+
 Here `$fields` is optional. If we do not pass `$fields` to get the selective fields, then it will return default fields in the resposnse.
 
 Here the response is PccPhpSdk\api\Response\Article.
@@ -62,20 +66,59 @@ Here the response is PccPhpSdk\api\Response\Article.
 ### Preview Article (By ID / Slug)
 
 To view latest modifications of the article which are not published, we can use `REALTIME` publishing level together with ArticlesAPI.
-To get preview of the article use `publishingLevel` argument as following. 
+To get preview of the article use `publishingLevel` argument as following.
 
 ```php
 $contentApi = new ArticlesApi($pccClient);
 $id = 'id-goes-here';
 $fields = ['id', 'snippet', 'slug', 'title'];
-$article1 = $articlesApi->getArticleById($id, $fields);
 $publishingLevel = \PccPhpSdk\api\Query\Enums\PublishingLevel::REALTIME;
+$article1 = $articlesApi->getArticleById($id, $fields, $publishingLevel);
 
 $slug = 'slug-goes-here';
 $article2 = $articlesApi->getArticleBySlug($slug, $fields, $publishingLevel);
 ```
 
-Apart from reusing already created PCC Client created above, preview of the article can also be fetched without site token and by using the PCC Grant.
+### Draft Article (By ID / Slug)
+
+To view draft versions of articles, you can use the `DRAFT` publishing level:
+
+```php
+$contentApi = new ArticlesApi($pccClient);
+$id = 'id-goes-here';
+$fields = ['id', 'snippet', 'slug', 'title'];
+$publishingLevel = \PccPhpSdk\api\Query\Enums\PublishingLevel::DRAFT;
+$article1 = $articlesApi->getArticleById($id, $fields, $publishingLevel);
+
+$slug = 'slug-goes-here';
+$article2 = $articlesApi->getArticleBySlug($slug, $fields, $publishingLevel);
+```
+
+### Getting Specific Version of Article (By ID / Slug)
+
+You can fetch a specific version of an article using the `versionId` parameter. This is useful when you need to access a particular revision of an article:
+
+```php
+$contentApi = new ArticlesApi($pccClient);
+$id = 'id-goes-here';
+$versionId = 'version-id-here';
+$fields = ['id', 'snippet', 'slug', 'title', 'content'];
+$publishingLevel = \PccPhpSdk\api\Query\Enums\PublishingLevel::DRAFT;
+$contentType = \PccPhpSdk\api\Query\Enums\ContentType::TREE_PANTHEON_V2;
+
+// Get specific version by article ID
+$article1 = $articlesApi->getArticleById($id, $fields, $publishingLevel, $contentType, $versionId);
+
+// Get specific version by article slug
+$slug = 'slug-goes-here';
+$article2 = $articlesApi->getArticleBySlug($slug, $fields, $publishingLevel, $versionId);
+```
+
+**Note**: Version ID support is only available for single article queries (`getArticleById` and `getArticleBySlug`). Article list queries (`getAllArticles`) do not support version IDs.
+
+### Using PCC Grant for Preview/Draft Articles
+
+Apart from reusing already created PCC Client created above, preview and draft articles can also be fetched without site token and by using the PCC Grant.
 
 ```php
 $pccClientConfig = new \PccPhpSdk\core\PccClientConfig(
@@ -88,9 +131,16 @@ $pccClient = new \PccPhpSdk\core\PccClient($pccClientConfig);
 $contentApi = new ArticlesApi($pccClient);
 $id = 'id-goes-here';
 $fields = ['id', 'snippet', 'slug', 'title'];
-$article1 = $articlesApi->getArticleById($id, $fields);
-$publishingLevel = \PccPhpSdk\api\Query\Enums\PublishingLevel::REALTIME;
 
-$slug = 'slug-goes-here';
-$article2 = $articlesApi->getArticleBySlug($slug, $fields, $publishingLevel);
+// Get realtime version with PCC Grant
+$publishingLevel = \PccPhpSdk\api\Query\Enums\PublishingLevel::REALTIME;
+$article1 = $articlesApi->getArticleById($id, $fields, $publishingLevel);
+
+// Get draft version with PCC Grant
+$publishingLevel = \PccPhpSdk\api\Query\Enums\PublishingLevel::DRAFT;
+$article2 = $articlesApi->getArticleById($id, $fields, $publishingLevel);
+
+// Get specific version with PCC Grant
+$versionId = 'version-id-here';
+$article3 = $articlesApi->getArticleById($id, $fields, $publishingLevel, null, $versionId);
 ```

--- a/src/api/ArticlesApi.php
+++ b/src/api/ArticlesApi.php
@@ -59,15 +59,19 @@ class ArticlesApi extends PccApi {
    *   The Article fields.
    * @param PublishingLevel $publishingLevel
    *   The publishing level.
+   * @param ContentType|null $contentType
+   *   The content type.
+   * @param string|null $versionId
+   *   The version ID.
    *
    * @return \PccPhpSdk\api\Response\Article|null
    *   Return Article response object.
    *
    * @throws \PccPhpSdk\Exception\PccClientException
    */
-  public function getArticleById(string $id, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null): ?Article {
-	$articleEntity = $this->articlesManager->getArticleById(...func_get_args());
-    return $articleEntity ? ResponseBuilder::toArticleResponse($articleEntity) : NULL;
+  public function getArticleById(string $id, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null, ?string $versionId = null): ?Article {
+    $article = $this->articlesManager->getArticleById($id, $fields, $publishingLevel, $contentType, $versionId);
+    return $article ? ResponseBuilder::toArticleResponse($article) : null;
   }
 
   /**
@@ -78,16 +82,18 @@ class ArticlesApi extends PccApi {
    * @param array $fields
    *   The Article fields.
    * @param PublishingLevel $publishingLevel
-   *   The publishing Level.
+   *   The publishing level.
+   * @param string|null $versionId
+   *   The version ID.
    *
    * @return \PccPhpSdk\api\Response\Article|null
    *   Return Article response object.
    *
    * @throws \PccPhpSdk\Exception\PccClientException
    */
-  public function getArticleBySlug(string $slug, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION): ?Article {
-    $articleEntity = $this->articlesManager->getArticleBySlug($slug, $fields, $publishingLevel);
-    return $articleEntity ? ResponseBuilder::toArticleResponse($articleEntity) : NULL;
+  public function getArticleBySlug(string $slug, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?string $versionId = null): ?Article {
+    $article = $this->articlesManager->getArticleBySlug($slug, $fields, $publishingLevel, $versionId);
+    return $article ? ResponseBuilder::toArticleResponse($article) : null;
   }
 
 }

--- a/src/api/Query/Enums/PublishStatus.php
+++ b/src/api/Query/Enums/PublishStatus.php
@@ -8,4 +8,5 @@ namespace PccPhpSdk\api\Query\Enums;
 enum PublishStatus: string {
   case PUBLISHED = 'published';
   case UNPUBLISHED = 'unpublished';
+  case DRAFT = 'draft';
 }

--- a/src/api/Query/Enums/PublishingLevel.php
+++ b/src/api/Query/Enums/PublishingLevel.php
@@ -5,4 +5,5 @@ namespace PccPhpSdk\api\Query\Enums;
 enum PublishingLevel: string {
   case PRODUCTION = 'PRODUCTION';
   case REALTIME = 'REALTIME';
+  case DRAFT = 'DRAFT';
 }

--- a/src/core/Entity/Loader/ArticleLoader.php
+++ b/src/core/Entity/Loader/ArticleLoader.php
@@ -49,7 +49,8 @@ class ArticleLoader implements ArticleLoaderInterface
         string $id,
         array $fields = [],
         PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
-        ?ContentType $contentType = null
+        ?ContentType $contentType = null,
+        ?string $versionId = null
     ): ?Article {
         $queryBuilder = new ArticleQueryBuilder();
         $queryBuilder->addFields($this->getFields($fields));
@@ -57,6 +58,9 @@ class ArticleLoader implements ArticleLoaderInterface
         $queryBuilder->setPublishingLevel($publishingLevel);
         if ($contentType) {
             $queryBuilder->setContentType($contentType);
+        }
+        if ($versionId) {
+            $queryBuilder->setVersionId($versionId);
         }
 
         $query = $queryBuilder->build();
@@ -316,12 +320,16 @@ class ArticleLoader implements ArticleLoaderInterface
     public function loadBySlug(
         string $slug,
         array $fields = [],
-        PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION
+        PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+        ?string $versionId = null
     ): ?Article {
         $queryBuilder = new ArticleQueryBuilder();
         $queryBuilder->addFields($this->getFields($fields));
         $queryBuilder->filterBySlug($slug);
         $queryBuilder->setPublishingLevel($publishingLevel);
+        if ($versionId) {
+            $queryBuilder->setVersionId($versionId);
+        }
 
         $query = $queryBuilder->build();
         $response = $this->sendRequest($query);

--- a/src/core/Entity/Loader/ArticleLoaderInterface.php
+++ b/src/core/Entity/Loader/ArticleLoaderInterface.php
@@ -33,11 +33,15 @@ interface ArticleLoaderInterface {
    *   The Article fields.
    * @param PublishingLevel $publishingLevel
    *     The publishing Level.
+   * @param ContentType|null $contentType
+   *   The content type.
+   * @param string|null $versionId
+   *   The version ID.
    *
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity or null.
    */
-  public function loadById(string $id, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null): ?Article;
+  public function loadById(string $id, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null, ?string $versionId = null): ?Article;
 
   /**
    * Load Article by slug.
@@ -48,11 +52,13 @@ interface ArticleLoaderInterface {
    *   The Article fields.
    * @param PublishingLevel $publishingLevel
    *     The publishing Level.
+   * @param string|null $versionId
+   *   The version ID.
    *
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article or null.
    */
-  public function loadBySlug(string $slug, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION): ?Article;
+  public function loadBySlug(string $slug, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?string $versionId = null): ?Article;
 
   /**
    * Load All Articles based on Query and Search args.

--- a/src/core/Query/Builder/Article/ArticleQueryBuilder.php
+++ b/src/core/Query/Builder/Article/ArticleQueryBuilder.php
@@ -44,6 +44,13 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
   private ContentType $content_type = ContentType::TEXT_MARKDOWN;
 
   /**
+   * Version ID.
+   *
+   * @var string|null
+   */
+  private ?string $version_id = null;
+
+  /**
    * Add ID for filter in the query.
    *
    * @param string $id
@@ -102,6 +109,20 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
   }
 
   /**
+   * Set version ID.
+   *
+   * @param ?string $version_id
+   *   Version ID.
+   *
+   * @return QueryBuilderInterface
+   *   Return self.
+   */
+  public function setVersionId(?string $version_id): QueryBuilderInterface {
+    $this->version_id = $version_id;
+    return $this;
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function build(): QueryInterface {
@@ -146,6 +167,9 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
       $value[ArticleLoaderInterface::SLUG] = $this->slug;
     }
     $value[Variables::PUBLISHING_LEVEL] = $this->publishing_level;
+    if ($this->version_id !== null) {
+      $value[Variables::VERSION_ID] = $this->version_id;
+    }
 
     return new \ArrayObject($value);
   }
@@ -165,6 +189,9 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
       $variable = [ArticleLoaderInterface::SLUG => $this->buildSlugVariableDef()];
     }
     $variable[Variables::PUBLISHING_LEVEL] = $this->buildPublishingLevelVariableDef();
+    if ($this->version_id !== null) {
+      $variable[Variables::VERSION_ID] = Variables::getVariableDefinition(Variables::VERSION_ID);
+    }
 
     return $variable;
   }

--- a/src/core/Query/Builder/Article/Variables.php
+++ b/src/core/Query/Builder/Article/Variables.php
@@ -19,6 +19,7 @@ class Variables {
   public const CONTENT_TYPE = 'contentType';
 
   public const PUBLISHING_LEVEL = 'publishingLevel';
+  public const VERSION_ID = 'versionId';
 
   /**
    * Get variable definition based on the field name.
@@ -53,6 +54,9 @@ class Variables {
 
       case self::PUBLISHING_LEVEL:
         return new Variable(self::PUBLISHING_LEVEL, 'PublishingLevel');
+
+      case self::VERSION_ID:
+        return new Variable(self::VERSION_ID, 'String');
 
       default:
         return NULL;

--- a/src/core/Services/ArticlesManager.php
+++ b/src/core/Services/ArticlesManager.php
@@ -58,16 +58,20 @@ class ArticlesManager {
    *   The Article fields.
    * @param PublishingLevel $publishingLevel
    *    The publishing Level.
+   * @param ContentType|null $contentType
+   *   The content type.
+   * @param string|null $versionId
+   *   The version ID.
    *
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity.
    */
-  public function getArticleById(string $id, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null): ?Article {
+  public function getArticleById(string $id, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null, ?string $versionId = null): ?Article {
 	  return $this->articleLoader->loadById(...func_get_args());
   }
 
   /**
-   * Get Article bu slug.
+   * Get Article by Slug.
    *
    * @param string $slug
    *   Article slug.
@@ -75,12 +79,14 @@ class ArticlesManager {
    *   The Article fields.
    * @param PublishingLevel $publishingLevel
    *    The publishing Level.
+   * @param string|null $versionId
+   *   The version ID.
    *
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity.
    */
-  public function getArticleBySlug(string $slug, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION): ?Article {
-    return $this->articleLoader->loadBySlug($slug, $fields, $publishingLevel);
+  public function getArticleBySlug(string $slug, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?string $versionId = null): ?Article {
+    return $this->articleLoader->loadBySlug(...func_get_args());
   }
 
 }


### PR DESCRIPTION
# Oveview
Adds support to the SDK for fetching `DRAFT` publishing levels and version ids, with the goal of supporting the approval workflow in Wordpress and Drupal

# Changes
- Updated `getArticleById` and `getArticleBySlug` methods to accept `versionId` parameter.
- Introduced `DRAFT` publishing level in `PublishingLevel` enum.
- Updated documentation in README