### PR TITLE
[PCC 2345] Add core status builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,34 @@ $article2 = $articlesApi->getArticleById($id, $fields, $publishingLevel);
 $versionId = 'version-id-here';
 $article3 = $articlesApi->getArticleById($id, $fields, $publishingLevel, null, $versionId);
 ```
+
+## Status
+
+```php
+use PccPhpSdk\core\PccClientConfig;
+use PccPhpSdk\core\Status\Status;
+use PccPhpSdk\core\Status\StatusLevel;
+use PccPhpSdk\core\Status\StatusOptions;
+
+$config = new PccClientConfig('--site-id--', '--site-token--');
+$options = new StatusOptions(
+  smartComponents: true,
+  smartComponentsCount: 7,
+  smartComponentPreview: true,
+  metadataGroups: false,
+  metadataGroupIdentifiers: null,
+  resolvePathConfigured: true,
+  notFoundPath: '/404'
+);
+
+$status = new Status($config, $options);
+$platformStatus = $status->withPlatform([
+  'name' => 'wordpress',
+  'version' => '6.6.2',
+  'sdk' => ['name' => 'pcc-wp-sdk', 'version' => 'x.x.x'],
+]);
+
+$payload = $platformStatus->toArray();
+
+// return json_encode($payload);
+```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "pantheon-systems/pcc-php-sdk",
   "description": "SDK Library for PCC Integration.",
+  "version": "1.1.0",
   "type": "library",
   "homepage": "https://github.com/pantheon-systems/pcc-php-sdk/",
   "require": {

--- a/src/core/Status/Status.php
+++ b/src/core/Status/Status.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PccPhpSdk\core\Status;
+
+use PccPhpSdk\core\PccClientConfig;
+
+const VERSION = '1.1.0';
+
+class Status
+{
+  private array $status;
+
+  public function __construct(PccClientConfig $config, StatusOptions $options)
+  {
+    $this->status = [
+      'timestamp' => gmdate('c'),
+      'level' => StatusLevel::BASIC->value,
+      'version' => VERSION,
+      'siteId' => $config->getSiteId(),
+      'smartComponents' => (bool) $options->smartComponents,
+      'smartComponentsCount' => $options->smartComponentsCount,
+      'smartComponentPreview' => (bool) $options->smartComponentPreview,
+      'metadataGroups' => (bool) $options->metadataGroups,
+      'metadataGroupIdentifiers' => $options->metadataGroupIdentifiers,
+      'resolvePathConfigured' => (bool) $options->resolvePathConfigured,
+      'notFoundPath' => $options->notFoundPath,
+    ];
+  }
+
+  public function withPlatform(array $platform): self
+  {
+    $clone = clone $this;
+    $clone->status['platform'] = $platform;
+    return $clone;
+  }
+
+  public function toArray(): array
+  {
+    return $this->status;
+  }
+}

--- a/src/core/Status/StatusOptions.php
+++ b/src/core/Status/StatusOptions.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PccPhpSdk\core\Status;
+
+enum StatusLevel: string
+{
+  case BASIC = 'basic';
+  case DEBUG = 'debug';
+}
+
+class StatusOptions
+{
+  public bool $smartComponents;
+  public ?int $smartComponentsCount;
+  public bool $smartComponentPreview;
+  public bool $metadataGroups;
+  /** @var string[]|null */
+  public ?array $metadataGroupIdentifiers;
+  public bool $resolvePathConfigured;
+  public string $notFoundPath;
+
+  public function __construct(
+    bool $smartComponents = false,
+    ?int $smartComponentsCount = null,
+    bool $smartComponentPreview = false,
+    bool $metadataGroups = false,
+    ?array $metadataGroupIdentifiers = null,
+    bool $resolvePathConfigured = false,
+    string $notFoundPath = '/404'
+  ) {
+    $this->smartComponents = $smartComponents;
+    $this->smartComponentsCount = $smartComponentsCount;
+    $this->smartComponentPreview = $smartComponentPreview;
+    $this->metadataGroups = $metadataGroups;
+    $this->metadataGroupIdentifiers = $metadataGroupIdentifiers;
+    $this->resolvePathConfigured = $resolvePathConfigured;
+    $this->notFoundPath = $notFoundPath;
+  }
+}


### PR DESCRIPTION
# Overview
Adds core status builder to be used by WP and Drupal for returning compliant client SDK `/status` responses