### PR TITLE
Code formatting fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock 

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
   },
   "require-dev": {
     "phpcompatibility/php-compatibility": "^9.3",
-    "squizzlabs/php_codesniffer": "^3.7",
+    "squizlabs/php_codesniffer": "^3.7",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
   },
   "scripts": {
     "lint": "vendor/bin/phpcs --standard=phpcs.xml --extensions=php --report=full",
+    "lint:fix": "vendor/bin/phpcbf --standard=phpcs.xml --extensions=php",
     "phpcomp": "vendor/bin/phpcs --standard=phpcs-comp.xml --report=source"
   },
   "config": {

--- a/phpcs-comp.xml
+++ b/phpcs-comp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="PCC PHP SDK Compatibility">
+  <description>Compatibility checks for PHP 8+.</description>
+
+  <file>src</file>
+  <exclude-pattern>vendor/*</exclude-pattern>
+
+  <rule ref="PHPCompatibility"/>
+  <config name="testVersion" value="8.0-"/>
+</ruleset> 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="PCC PHP SDK">
+  <description>PSR-12 baseline adapted for project style (2-space indentation) with PHPCompatibility for PHP 8+.</description>
+
+  <file>src</file>
+  <exclude-pattern>vendor/*</exclude-pattern>
+
+  <rule ref="PSR12">
+    <exclude name="PSR12.Properties.ConstantVisibility"/>
+  </rule>
+
+  <rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+      <property name="indent" value="2"/>
+      <property name="tabIndent" value="false"/>
+    </properties>
+  </rule>
+
+  <rule ref="PHPCompatibility"/>
+  <config name="testVersion" value="8.0-"/>
+</ruleset> 

--- a/src/Exception/PccClientException.php
+++ b/src/Exception/PccClientException.php
@@ -2,8 +2,8 @@
 
 namespace PccPhpSdk\Exception;
 
-
 use GuzzleHttp\Exception\RequestException;
 
-class PccClientException extends RequestException {
+class PccClientException extends RequestException
+{
 }

--- a/src/api/ArticlesApi.php
+++ b/src/api/ArticlesApi.php
@@ -15,8 +15,8 @@ use PccPhpSdk\core\Services\ArticlesManager;
 /**
  * Articles API to fetch articles.
  */
-class ArticlesApi extends PccApi {
-
+class ArticlesApi extends PccApi
+{
   /**
    * Internal Articles Manager Service.
    *
@@ -27,7 +27,8 @@ class ArticlesApi extends PccApi {
   /**
    * {@inheritDoc}
    */
-  public function __construct(PccClient $pccClient) {
+  public function __construct(PccClient $pccClient)
+  {
     parent::__construct($pccClient);
     $this->articlesManager = new ArticlesManager($pccClient);
   }
@@ -45,7 +46,11 @@ class ArticlesApi extends PccApi {
    * @return \PccPhpSdk\api\Response\PaginatedArticles
    *   Returns articles list matching the search criterion as PaginatedArticles.
    */
-  public function getAllArticles(?ArticleQueryArgs $queryArgs = NULL, ?ArticleSearchArgs $searchArgs = NULL, array $fields=[]): PaginatedArticles {
+  public function getAllArticles(
+      ?ArticleQueryArgs $queryArgs = null,
+      ?ArticleSearchArgs $searchArgs = null,
+      array $fields = []
+  ): PaginatedArticles {
     $articles = $this->articlesManager->getArticles($queryArgs, $searchArgs, $fields);
     return ResponseBuilder::toPaginatedArticles($articles);
   }
@@ -69,7 +74,13 @@ class ArticlesApi extends PccApi {
    *
    * @throws \PccPhpSdk\Exception\PccClientException
    */
-  public function getArticleById(string $articleId, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null, ?string $versionId = null): ?Article {
+  public function getArticleById(
+      string $articleId,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?ContentType $contentType = null,
+      ?string $versionId = null
+  ): ?Article {
     $article = $this->articlesManager->getArticleById($articleId, $fields, $publishingLevel, $contentType, $versionId);
     return $article ? ResponseBuilder::toArticleResponse($article) : null;
   }
@@ -91,9 +102,13 @@ class ArticlesApi extends PccApi {
    *
    * @throws \PccPhpSdk\Exception\PccClientException
    */
-  public function getArticleBySlug(string $slug, array $fields = [], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?string $versionId = null): ?Article {
+  public function getArticleBySlug(
+      string $slug,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?string $versionId = null
+  ): ?Article {
     $article = $this->articlesManager->getArticleBySlug($slug, $fields, $publishingLevel, $versionId);
     return $article ? ResponseBuilder::toArticleResponse($article) : null;
   }
-
 }

--- a/src/api/PccApi.php
+++ b/src/api/PccApi.php
@@ -7,8 +7,8 @@ use PccPhpSdk\core\PccClient;
 /**
  * PccAPI class providing underlying required functionalities for APIs.
  */
-abstract class PccApi {
-
+abstract class PccApi
+{
   /**
    *  PccClient.
    *
@@ -22,7 +22,8 @@ abstract class PccApi {
    * @param PccClient $pccClient
    *   Preconfigured PccClient
    */
-  public function __construct(PccClient $pccClient) {
+  public function __construct(PccClient $pccClient)
+  {
     $this->pccClient = $pccClient;
   }
 }

--- a/src/api/Query/ArticleQueryArgs.php
+++ b/src/api/Query/ArticleQueryArgs.php
@@ -13,8 +13,8 @@ use PccPhpSdk\api\Query\Enums\ContentType;
  *
  * @package PccPhpSdk\api\Query
  */
-class ArticleQueryArgs {
-
+class ArticleQueryArgs
+{
   /**
    * The type of content to query.
    *
@@ -65,11 +65,11 @@ class ArticleQueryArgs {
    *   The type of content to query.
    */
   public function __construct(
-    ArticleSortField $sortField = ArticleSortField::UPDATED_AT,
-    ArticleSortOrder $sortOrder = ArticleSortOrder::DESC,
-    int $pageSize = 10,
-    int $pageIndex = 1,
-    ContentType $contentType = ContentType::TEXT_MARKDOWN,
+      ArticleSortField $sortField = ArticleSortField::UPDATED_AT,
+      ArticleSortOrder $sortOrder = ArticleSortOrder::DESC,
+      int $pageSize = 10,
+      int $pageIndex = 1,
+      ContentType $contentType = ContentType::TEXT_MARKDOWN,
   ) {
     $this->contentType = $contentType;
     $this->sortField = $sortField;
@@ -84,7 +84,8 @@ class ArticleQueryArgs {
    * @param ContentType $contentType
    *   The type of content to query.
    */
-  public function setContentType(ContentType $contentType): void {
+  public function setContentType(ContentType $contentType): void
+  {
     $this->contentType = $contentType;
   }
 
@@ -94,7 +95,8 @@ class ArticleQueryArgs {
    * @param ArticleSortField $sortField
    *   The field by which to sort the articles.
    */
-  public function setSortField(ArticleSortField $sortField): void {
+  public function setSortField(ArticleSortField $sortField): void
+  {
     $this->sortField = $sortField;
   }
 
@@ -104,7 +106,8 @@ class ArticleQueryArgs {
    * @param ArticleSortOrder $sortOrder
    *   The order in which to sort the articles.
    */
-  public function setSortOrder(ArticleSortOrder $sortOrder): void {
+  public function setSortOrder(ArticleSortOrder $sortOrder): void
+  {
     $this->sortOrder = $sortOrder;
   }
 
@@ -114,7 +117,8 @@ class ArticleQueryArgs {
    * @param int $pageSize
    *   The number of articles per page.
    */
-  public function setPageSize(int $pageSize): void {
+  public function setPageSize(int $pageSize): void
+  {
     $this->pageSize = $pageSize;
   }
 
@@ -124,7 +128,8 @@ class ArticleQueryArgs {
    * @param int $pageIndex
    *   The index of the page to retrieve.
    */
-  public function setPageIndex(int $pageIndex): void {
+  public function setPageIndex(int $pageIndex): void
+  {
     $this->pageIndex = $pageIndex;
   }
 
@@ -134,7 +139,8 @@ class ArticleQueryArgs {
    * @return ContentType
    *   The type of content to query.
    */
-  public function getContentType(): ContentType {
+  public function getContentType(): ContentType
+  {
     return $this->contentType;
   }
 
@@ -144,7 +150,8 @@ class ArticleQueryArgs {
    * @return ArticleSortField
    *   The field by which to sort the articles.
    */
-  public function getSortField(): ArticleSortField {
+  public function getSortField(): ArticleSortField
+  {
     return $this->sortField;
   }
 
@@ -154,7 +161,8 @@ class ArticleQueryArgs {
    * @return ArticleSortOrder
    *   The order in which to sort the articles.
    */
-  public function getSortOrder(): ArticleSortOrder {
+  public function getSortOrder(): ArticleSortOrder
+  {
     return $this->sortOrder;
   }
 
@@ -164,7 +172,8 @@ class ArticleQueryArgs {
    * @return int
    *   The number of articles per page.
    */
-  public function getPageSize(): int {
+  public function getPageSize(): int
+  {
     return $this->pageSize;
   }
 
@@ -174,8 +183,8 @@ class ArticleQueryArgs {
    * @return int
    *   The index of the page to retrieve.
    */
-  public function getPageIndex(): int {
+  public function getPageIndex(): int
+  {
     return $this->pageIndex;
   }
-
 }

--- a/src/api/Query/ArticleSearchArgs.php
+++ b/src/api/Query/ArticleSearchArgs.php
@@ -11,8 +11,8 @@ use PccPhpSdk\api\query\Enums\PublishStatus;
  *
  * @package PccPhpSdk\api\Query
  */
-class ArticleSearchArgs {
-
+class ArticleSearchArgs
+{
   /**
    * @var string $bodyContains
    *
@@ -55,7 +55,12 @@ class ArticleSearchArgs {
    * @param PublishStatus $publishStatus
    *   The publishing status to filter articles by.
    */
-  public function __construct(string $bodyContains = '', string $tagContains = '', string $titleContains = '', PublishStatus $publishStatus = PublishStatus::PUBLISHED) {
+  public function __construct(
+      string $bodyContains = '',
+      string $tagContains = '',
+      string $titleContains = '',
+      PublishStatus $publishStatus = PublishStatus::PUBLISHED
+  ) {
     $this->bodyContains = $bodyContains;
     $this->tagContains = $tagContains;
     $this->titleContains = $titleContains;
@@ -68,7 +73,8 @@ class ArticleSearchArgs {
    * @param string $bodyContains
    *   The string to search for within the body of articles.
    */
-  public function setBodyContains(string $bodyContains): void {
+  public function setBodyContains(string $bodyContains): void
+  {
     $this->bodyContains = $bodyContains;
   }
 
@@ -78,7 +84,8 @@ class ArticleSearchArgs {
    * @param string $tagContains
    *   The string to search for within the tags of articles.
    */
-  public function setTagContains(string $tagContains): void {
+  public function setTagContains(string $tagContains): void
+  {
     $this->tagContains = $tagContains;
   }
 
@@ -88,7 +95,8 @@ class ArticleSearchArgs {
    * @param string $titleContains
    *   The string to search for within the title of articles.
    */
-  public function setTitleContains(string $titleContains): void {
+  public function setTitleContains(string $titleContains): void
+  {
     $this->titleContains = $titleContains;
   }
 
@@ -98,7 +106,8 @@ class ArticleSearchArgs {
    * @param PublishStatus $publishStatus
    *   The publishing status to filter articles by.
    */
-  public function setPublishStatus(PublishStatus $publishStatus): void {
+  public function setPublishStatus(PublishStatus $publishStatus): void
+  {
     $this->publishStatus = $publishStatus;
   }
 
@@ -108,7 +117,8 @@ class ArticleSearchArgs {
    * @return string
    *   The string to search for within the body of articles.
    */
-  public function getBodyContains(): string {
+  public function getBodyContains(): string
+  {
     return $this->bodyContains;
   }
 
@@ -118,7 +128,8 @@ class ArticleSearchArgs {
    * @return string
    *   The string to search for within the tags of articles.
    */
-  public function getTagContains(): string {
+  public function getTagContains(): string
+  {
     return $this->tagContains;
   }
 
@@ -128,7 +139,8 @@ class ArticleSearchArgs {
    * @return string
    *   The string to search for within the title of articles.
    */
-  public function getTitleContains(): string {
+  public function getTitleContains(): string
+  {
     return $this->titleContains;
   }
 
@@ -138,8 +150,8 @@ class ArticleSearchArgs {
    * @return PublishStatus
    *   The publishing status to filter articles by.
    */
-  public function getPublishStatus(): PublishStatus {
+  public function getPublishStatus(): PublishStatus
+  {
     return $this->publishStatus;
   }
-
 }

--- a/src/api/Query/Enums/ArticleSortField.php
+++ b/src/api/Query/Enums/ArticleSortField.php
@@ -5,7 +5,8 @@ namespace PccPhpSdk\api\Query\Enums;
 /**
  * Article Sortable Fields.
  */
-enum ArticleSortField: string {
+enum ArticleSortField: string
+{
   case CREATED_AT = 'createdAt';
   case UPDATED_AT = 'updatedAt';
 }

--- a/src/api/Query/Enums/ArticleSortOrder.php
+++ b/src/api/Query/Enums/ArticleSortOrder.php
@@ -5,7 +5,8 @@ namespace PccPhpSdk\api\Query\Enums;
 /**
  * Article Sort Order.
  */
-enum ArticleSortOrder: string {
+enum ArticleSortOrder: string
+{
   case ASC = 'ASC';
   case DESC = 'DESC';
 }

--- a/src/api/Query/Enums/ContentType.php
+++ b/src/api/Query/Enums/ContentType.php
@@ -5,7 +5,8 @@ namespace PccPhpSdk\api\Query\Enums;
 /**
  * Supported Content Types.
  */
-enum ContentType: string {
+enum ContentType: string
+{
   case TEXT_MARKDOWN = 'TEXT_MARKDOWN';
   case TREE_PANTHEON = 'TREE_PANTHEON';
   case TREE_PANTHEON_V2 = 'TREE_PANTHEON_V2';

--- a/src/api/Query/Enums/PublishStatus.php
+++ b/src/api/Query/Enums/PublishStatus.php
@@ -5,7 +5,8 @@ namespace PccPhpSdk\api\Query\Enums;
 /**
  * Supported Publish Status.
  */
-enum PublishStatus: string {
+enum PublishStatus: string
+{
     case PUBLISHED = 'published';
     case UNPUBLISHED = 'unpublished';
     case DRAFT = 'draft';

--- a/src/api/Query/Enums/PublishingLevel.php
+++ b/src/api/Query/Enums/PublishingLevel.php
@@ -2,7 +2,8 @@
 
 namespace PccPhpSdk\api\Query\Enums;
 
-enum PublishingLevel: string {
+enum PublishingLevel: string
+{
     case PRODUCTION = 'PRODUCTION';
     case REALTIME = 'REALTIME';
     case DRAFT = 'DRAFT';

--- a/src/api/Response/Article.php
+++ b/src/api/Response/Article.php
@@ -8,8 +8,8 @@ namespace PccPhpSdk\api\Response;
  * Response object containing Article data.
  */
 #[\AllowDynamicProperties]
-class Article {
-
+class Article
+{
   /**
    * Article ID.
    *

--- a/src/api/Response/Builder/ResponseBuilder.php
+++ b/src/api/Response/Builder/ResponseBuilder.php
@@ -12,8 +12,8 @@ use PccPhpSdk\core\Entity\ArticlesList;
  * Provides static methods to convert internal Entities to Response objects.
  */
 #[\AllowDynamicProperties]
-class ResponseBuilder {
-
+class ResponseBuilder
+{
   /**
    * Cast to Article Response.
    *
@@ -23,8 +23,9 @@ class ResponseBuilder {
    * @return \PccPhpSdk\api\Response\Article
    *   Article Response object.
    */
-  public static function toArticleResponse(ArticleEntity $entity): Article {
-    $response = NULL;
+  public static function toArticleResponse(ArticleEntity $entity): Article
+  {
+    $response = null;
     if (!empty($entity)) {
       $entity_properties = get_object_vars($entity);
       $response = new Article();
@@ -45,7 +46,8 @@ class ResponseBuilder {
    * @return \PccPhpSdk\api\Response\PaginatedArticles
    *   PaginatedArticles Response Object.
    */
-  public static function toPaginatedArticles(ArticlesList $articlesList): PaginatedArticles {
+  public static function toPaginatedArticles(ArticlesList $articlesList): PaginatedArticles
+  {
     $response = new PaginatedArticles();
     $response->articles = [];
     if ($articlesList->articles) {
@@ -57,5 +59,4 @@ class ResponseBuilder {
     $response->cursor = $articlesList->cursor;
     return $response;
   }
-
 }

--- a/src/api/Response/PaginatedArticles.php
+++ b/src/api/Response/PaginatedArticles.php
@@ -7,8 +7,8 @@ namespace PccPhpSdk\api\Response;
  *
  * Response Object containing articles and result summary.
  */
-class PaginatedArticles {
-
+class PaginatedArticles
+{
   /**
    * Array of articles.
    *
@@ -57,5 +57,4 @@ class PaginatedArticles {
    * @var int
    */
   public int $limit;
-
 }

--- a/src/api/SitesApi.php
+++ b/src/api/SitesApi.php
@@ -7,8 +7,8 @@ use PccPhpSdk\core\Query\GraphQLQuery;
 /**
  * Site API to get site.
  */
-class SitesApi extends PccApi {
-
+class SitesApi extends PccApi
+{
   /**
    * Get site.
    *
@@ -20,7 +20,8 @@ class SitesApi extends PccApi {
    *
    * @throws \PccPhpSdk\Exception\PccClientException
    */
-  public function getSite(string $siteId): mixed {
+  public function getSite(string $siteId): mixed
+  {
     // @todo Create SitesManager to get the site, similar to ArticlesManager.
     // Once we do this, we can Remove PccApi base class.
     $query = <<<'GRAPHQL'
@@ -37,5 +38,4 @@ class SitesApi extends PccApi {
     $graphQLQuery = new GraphQLQuery($query, $variables);
     return $this->pccClient->executeQuery($graphQLQuery);
   }
-
 }

--- a/src/core/Entity/Article.php
+++ b/src/core/Entity/Article.php
@@ -8,8 +8,8 @@ namespace PccPhpSdk\core\Entity;
  * Entity object containing Article data.
  */
 #[\AllowDynamicProperties]
-class Article {
-
+class Article
+{
   /**
    * Article ID.
    *

--- a/src/core/Entity/ArticlesList.php
+++ b/src/core/Entity/ArticlesList.php
@@ -7,7 +7,8 @@ namespace PccPhpSdk\core\Entity;
  *
  * Entity object containing Articles.
  */
-class ArticlesList {
+class ArticlesList
+{
   /**
    * Total number of articles.
    *
@@ -39,12 +40,13 @@ class ArticlesList {
    * @param int $cursor
    *   The current cursor.
    */
-  public function __construct(array $articles = [], $total = 20, int $cursor = NULL) {
+  public function __construct(array $articles = [], $total = 20, int $cursor = null)
+  {
     $this->articles = $articles;
     $this->total = $total;
-    if ($cursor === NULL) {
+    if ($cursor === null) {
       // Get the current Unix timestamp with microseconds.
-      $microtime = microtime(TRUE);
+      $microtime = microtime(true);
       // Convert to milliseconds.
       $this->cursor = round($microtime * 1000);
     }
@@ -54,12 +56,13 @@ class ArticlesList {
    * Add total count of articles.
    *
    * @param int $total
-   *   The toal cont.
+   *   The total cont.
    *
    * @return void
    *   Nothing.
    */
-  public function addTotalArticlesCount(int $total): void {
+  public function addTotalArticlesCount(int $total): void
+  {
     $this->total = $total;
   }
 
@@ -72,7 +75,8 @@ class ArticlesList {
    * @return void
    *   Nothing.
    */
-  public function addPageCursor(int $cursor): void {
+  public function addPageCursor(int $cursor): void
+  {
     $this->cursor = $cursor;
   }
 
@@ -85,8 +89,8 @@ class ArticlesList {
    * @return void
    *   Nothing.
    */
-  public function addArticle(Article $article): void {
+  public function addArticle(Article $article): void
+  {
     $this->articles[] = $article;
   }
-
 }

--- a/src/core/Entity/Loader/ArticleLoader.php
+++ b/src/core/Entity/Loader/ArticleLoader.php
@@ -23,13 +23,12 @@ use function is_array;
  */
 class ArticleLoader implements ArticleLoaderInterface
 {
-
     /**
      * PccClient.
      *
      * @var PccClient
      */
-    protected PccClient $pccClient;
+  protected PccClient $pccClient;
 
     /**
      * Constructor for Content API.
@@ -37,38 +36,38 @@ class ArticleLoader implements ArticleLoaderInterface
      * @param PccClient $pccClient
      *   Preconfigured PccClient.
      */
-    public function __construct(PccClient $pccClient)
-    {
-        $this->pccClient = $pccClient;
-    }
+  public function __construct(PccClient $pccClient)
+  {
+      $this->pccClient = $pccClient;
+  }
 
 
     /**
      * {@inheritDoc}
      */
-    public function loadById(
-        string $articleId,
-        array $fields=[],
-        PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
-        ?ContentType $contentType = null,
-        ?string $versionId = null
-    ): ?Article {
-        $queryBuilder = new ArticleQueryBuilder();
-        $queryBuilder->addFields($this->getFields($fields));
-        $queryBuilder->filterById($articleId);
-        $queryBuilder->setPublishingLevel($publishingLevel);
-        if ($contentType) {
-            $queryBuilder->setContentType($contentType);
-        }
-        if ($versionId) {
-            $queryBuilder->setVersionId($versionId);
-        }
-
-        $query = $queryBuilder->build();
-        $response = $this->sendRequest($query);
-        $response = $response['article'] ?: null;
-        return !empty($response) ? $this->toArticle($fields, $response, $contentType) : null;
+  public function loadById(
+      string $articleId,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?ContentType $contentType = null,
+      ?string $versionId = null
+  ): ?Article {
+      $queryBuilder = new ArticleQueryBuilder();
+      $queryBuilder->addFields($this->getFields($fields));
+      $queryBuilder->filterById($articleId);
+      $queryBuilder->setPublishingLevel($publishingLevel);
+    if ($contentType) {
+        $queryBuilder->setContentType($contentType);
     }
+    if ($versionId) {
+        $queryBuilder->setVersionId($versionId);
+    }
+
+      $query = $queryBuilder->build();
+      $response = $this->sendRequest($query);
+      $response = $response['article'] ?: null;
+      return !empty($response) ? $this->toArticle($fields, $response, $contentType) : null;
+  }
 
     /**
      * Get default article fields.
@@ -79,24 +78,24 @@ class ArticleLoader implements ArticleLoaderInterface
      * @return string[]
      *   Array of fields.
      */
-    protected function getFields(array $fields = []): array
-    {
-        if (!empty($fields)) {
-            return $fields;
-        }
-
-        return [
-            'id',
-            'slug',
-            'title',
-            'siteId',
-            'tags',
-            'content',
-            'snippet',
-            'publishedDate',
-            'updatedAt',
-        ];
+  protected function getFields(array $fields = []): array
+  {
+    if (!empty($fields)) {
+        return $fields;
     }
+
+      return [
+          'id',
+          'slug',
+          'title',
+          'siteId',
+          'tags',
+          'content',
+          'snippet',
+          'publishedDate',
+          'updatedAt',
+      ];
+  }
 
     /**
      * Send Request with query.
@@ -107,36 +106,36 @@ class ArticleLoader implements ArticleLoaderInterface
      * @return array
      *   Response data as array.
      */
-    private function sendRequest(QueryInterface $query): array
-    {
-        $response = $this->pccClient->executeQuery($query);
-        $jsonResponse = json_decode($response, true);
+  private function sendRequest(QueryInterface $query): array
+  {
+      $response = $this->pccClient->executeQuery($query);
+      $jsonResponse = json_decode($response, true);
 
-        if ($jsonResponse === null) {
-            throw new Exception('Failed to parse JSON response.');
-        }
-        if (!isset($jsonResponse['data']) || !is_array($jsonResponse['data'])) {
-            throw new Exception('Invalid JSON response structure.');
-        }
-
-        $result = [];
-
-        if (!empty($jsonResponse)) {
-            if (!empty($jsonResponse['data']['article'])) {
-                $result['article'] = $jsonResponse['data']['article'];
-            }
-            if (!empty($jsonResponse['data']['articles'])) {
-                $result['articles'] = $jsonResponse['data']['articles'];
-            }
-            if (!empty($jsonResponse['extensions']['pagination']['total'])) {
-                $result['total'] = $jsonResponse['extensions']['pagination']['total'];
-            }
-            if (!empty($jsonResponse['extensions']['pagination']['cursor'])) {
-                $result['cursor'] = $jsonResponse['extensions']['pagination']['cursor'];
-            }
-        }
-        return $result;
+    if ($jsonResponse === null) {
+        throw new Exception('Failed to parse JSON response.');
     }
+    if (!isset($jsonResponse['data']) || !is_array($jsonResponse['data'])) {
+        throw new Exception('Invalid JSON response structure.');
+    }
+
+      $result = [];
+
+    if (!empty($jsonResponse)) {
+      if (!empty($jsonResponse['data']['article'])) {
+          $result['article'] = $jsonResponse['data']['article'];
+      }
+      if (!empty($jsonResponse['data']['articles'])) {
+          $result['articles'] = $jsonResponse['data']['articles'];
+      }
+      if (!empty($jsonResponse['extensions']['pagination']['total'])) {
+          $result['total'] = $jsonResponse['extensions']['pagination']['total'];
+      }
+      if (!empty($jsonResponse['extensions']['pagination']['cursor'])) {
+          $result['cursor'] = $jsonResponse['extensions']['pagination']['cursor'];
+      }
+    }
+      return $result;
+  }
 
     /**
      * Parse response data to get Article.
@@ -151,40 +150,40 @@ class ArticleLoader implements ArticleLoaderInterface
      * @return Article|null
      *   Article entity or null.
      */
-    private function toArticle(array $fields, array $data, ?ContentType $contentType = null): ?Article
-    {
-        if (empty($data)) {
-            return null;
-        }
-
-        $article = new Article();
-        foreach ($this->getFields($fields) as $field) {
-            switch ($field) {
-                case 'tags':
-                    $article->{$field} = $data[$field] ?: [];
-                    break;
-
-                case 'snippet':
-                    $article->{$field} = $data[$field] ? $this->parseMarkdownToHtml($data[$field]) : '';
-                    break;
-                case 'content':
-                    if (!$data[$field]) {
-                        $article->{$field} = '';
-                        break;
-                    }
-                    if (ContentType::TREE_PANTHEON_V2 === $contentType) {
-                        $article->{$field} = $this->parseTreeToHtml($data[$field]);
-                        break;
-                    }
-                    $article->{$field} = $this->parseMarkdownToHtml($data[$field]);
-                    break;
-
-                default:
-                    $article->{$field} = $data[$field] ?? '';
-            }
-        }
-        return $article;
+  private function toArticle(array $fields, array $data, ?ContentType $contentType = null): ?Article
+  {
+    if (empty($data)) {
+        return null;
     }
+
+      $article = new Article();
+    foreach ($this->getFields($fields) as $field) {
+      switch ($field) {
+        case 'tags':
+          $article->{$field} = $data[$field] ?: [];
+            break;
+
+        case 'snippet':
+            $article->{$field} = $data[$field] ? $this->parseMarkdownToHtml($data[$field]) : '';
+            break;
+        case 'content':
+          if (!$data[$field]) {
+              $article->{$field} = '';
+              break;
+          }
+          if (ContentType::TREE_PANTHEON_V2 === $contentType) {
+              $article->{$field} = $this->parseTreeToHtml($data[$field]);
+              break;
+          }
+            $article->{$field} = $this->parseMarkdownToHtml($data[$field]);
+            break;
+
+        default:
+            $article->{$field} = $data[$field] ?? '';
+      }
+    }
+      return $article;
+  }
 
     /**
      * Convert markdown format to html.
@@ -195,14 +194,14 @@ class ArticleLoader implements ArticleLoaderInterface
      * @return string
      *   Returns the html string.
      */
-    private function parseMarkdownToHtml(string $content): string
-    {
-        // Replace all occurrences of the pattern `{#h\..*}\n` with `\n`.
-        $pattern = '/{#h\..*}\n/';
-        $content = preg_replace($pattern, "\n", $content);
-        $parsedown = new Parsedown();
-        return $parsedown->text($content);
-    }
+  private function parseMarkdownToHtml(string $content): string
+  {
+      // Replace all occurrences of the pattern `{#h\..*}\n` with `\n`.
+      $pattern = '/{#h\..*}\n/';
+      $content = preg_replace($pattern, "\n", $content);
+      $parsedown = new Parsedown();
+      return $parsedown->text($content);
+  }
 
     /**
      * Parse TREE_PANTHEON_V2 response data to HTML.
@@ -211,16 +210,16 @@ class ArticleLoader implements ArticleLoaderInterface
      *
      * @return string
      */
-    private function parseTreeToHtml(string $content): string
-    {
-        $array = json_decode($content, true);
-        $array = is_array($array) ? $array : [];
-        $class = 'scoped-' . substr(md5(mt_rand()), 0, 9);
-        $html = '';
-        $this->processNode($array, $html, $class);
+  private function parseTreeToHtml(string $content): string
+  {
+      $array = json_decode($content, true);
+      $array = is_array($array) ? $array : [];
+      $class = 'scoped-' . substr(md5(mt_rand()), 0, 9);
+      $html = '';
+      $this->processNode($array, $html, $class);
 
-        return $this->createElement('div', ['class' => $class], [], $html);
-    }
+      return $this->createElement('div', ['class' => $class], [], $html);
+  }
 
     /**
      * Processes a JSON node and appends the corresponding HTML to the output by reference.
@@ -231,37 +230,37 @@ class ArticleLoader implements ArticleLoaderInterface
      *
      * @return void
      */
-    private function processNode(array $node, string &$html_output, string $unique_class): void
-    {
-        $tag = $node['tag'] ?? 'div';
-        $data = $node['data'] ?? '';
-        $children = $node['children'] ?? [];
-        $style = $node['style'] ?? [];
-        $attrs = $node['attrs'] ?? [];
+  private function processNode(array $node, string &$html_output, string $unique_class): void
+  {
+      $tag = $node['tag'] ?? 'div';
+      $data = $node['data'] ?? '';
+      $children = $node['children'] ?? [];
+      $style = $node['style'] ?? [];
+      $attrs = $node['attrs'] ?? [];
 
-        if (empty($children) && empty($data) && empty($attrs)) {
-            return;
-        }
-
-        if ($tag === 'style' && $data) {
-            $scoped_data = ".$unique_class $data";
-            $element = $this->createElement($tag, $attrs, $style, $scoped_data);
-            $html_output .= $element;
-            return;
-        }
-
-        $element = $this->createElement($tag, $attrs, $style, $data);
-
-        if (!empty($children)) {
-            $child_html = '';
-            foreach ($children as $child) {
-                $this->processNode($child, $child_html, $unique_class);
-            }
-            $element = str_replace('</' . $tag . '>', $child_html . '</' . $tag . '>', $element);
-        }
-
-        $html_output .= $element;
+    if (empty($children) && empty($data) && empty($attrs)) {
+        return;
     }
+
+    if ($tag === 'style' && $data) {
+        $scoped_data = ".$unique_class $data";
+        $element = $this->createElement($tag, $attrs, $style, $scoped_data);
+        $html_output .= $element;
+        return;
+    }
+
+      $element = $this->createElement($tag, $attrs, $style, $data);
+
+    if (!empty($children)) {
+        $child_html = '';
+      foreach ($children as $child) {
+          $this->processNode($child, $child_html, $unique_class);
+      }
+        $element = str_replace('</' . $tag . '>', $child_html . '</' . $tag . '>', $element);
+    }
+
+      $html_output .= $element;
+  }
 
     /**
      * Creates an HTML element with the specified tag, attributes, styles, and content.
@@ -272,102 +271,102 @@ class ArticleLoader implements ArticleLoaderInterface
      * @param string|null $content Optional. The content to place inside the element.
      * @return string The generated HTML element.
      */
-    private function createElement(
-        string $tag,
-        array $attrs = [],
-        array|string $styles = [],
-        ?string $content = ''
-    ): string {
-        if (!$tag) {
-            $tag = 'div';
-        }
-
-        $element = '<' . $tag;
-
-        foreach ($attrs as $key => $value) {
-            $element .= ' ' . $key . '="' . htmlspecialchars($value) . '"';
-        }
-
-        $style_string = '';
-        if (is_array($styles)) {
-            foreach ($styles as $style) {
-                [$key, $value] = array_map('trim', explode(':', $style));
-                $style_string .= $key . ':' . $value . ';';
-            }
-        } elseif (is_array($styles)) {
-            foreach ($styles as $key => $value) {
-                $style_string .= $key . ':' . $value . ';';
-            }
-        }
-
-        if ($style_string) {
-            $element .= ' style="' . htmlspecialchars($style_string) . '"';
-        }
-
-        $element .= '>';
-
-        if ($content !== null) {
-            $element .= $content;
-        }
-
-        $element .= '</' . $tag . '>';
-
-        return $element;
+  private function createElement(
+      string $tag,
+      array $attrs = [],
+      array|string $styles = [],
+      ?string $content = ''
+  ): string {
+    if (!$tag) {
+        $tag = 'div';
     }
+
+      $element = '<' . $tag;
+
+    foreach ($attrs as $key => $value) {
+        $element .= ' ' . $key . '="' . htmlspecialchars($value) . '"';
+    }
+
+      $style_string = '';
+    if (is_array($styles)) {
+      foreach ($styles as $style) {
+          [$key, $value] = array_map('trim', explode(':', $style));
+          $style_string .= $key . ':' . $value . ';';
+      }
+    } elseif (is_array($styles)) {
+      foreach ($styles as $key => $value) {
+          $style_string .= $key . ':' . $value . ';';
+      }
+    }
+
+    if ($style_string) {
+        $element .= ' style="' . htmlspecialchars($style_string) . '"';
+    }
+
+      $element .= '>';
+
+    if ($content !== null) {
+        $element .= $content;
+    }
+
+      $element .= '</' . $tag . '>';
+
+      return $element;
+  }
 
     /**
      * {@inheritDoc}
      */
-    public function loadBySlug(
-        string $slug,
-        array $fields=[],
-        PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
-        ?string $versionId = null
-    ): ?Article {
-        $queryBuilder = new ArticleQueryBuilder();
-        $queryBuilder->addFields($this->getFields($fields));
-        $queryBuilder->filterBySlug($slug);
-        $queryBuilder->setPublishingLevel($publishingLevel);
-        if ($versionId) {
-            $queryBuilder->setVersionId($versionId);
-        }
-
-        $query = $queryBuilder->build();
-        $response = $this->sendRequest($query);
-
-        $response = $response['article'] ?? null;
-        return !empty($response) ? $this->toArticle($fields, $response) : null;
+  public function loadBySlug(
+      string $slug,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?string $versionId = null
+  ): ?Article {
+      $queryBuilder = new ArticleQueryBuilder();
+      $queryBuilder->addFields($this->getFields($fields));
+      $queryBuilder->filterBySlug($slug);
+      $queryBuilder->setPublishingLevel($publishingLevel);
+    if ($versionId) {
+        $queryBuilder->setVersionId($versionId);
     }
+
+      $query = $queryBuilder->build();
+      $response = $this->sendRequest($query);
+
+      $response = $response['article'] ?? null;
+      return !empty($response) ? $this->toArticle($fields, $response) : null;
+  }
 
     /**
      * {@inheritDoc}
      */
-    public function loadAll(
-        ?ArticleQueryArgs $queryArgs,
-        ?ArticleSearchArgs $searchArgs,
-        array $fields = []
-    ): ArticlesList {
-        $queryBuilder = new ArticlesListQueryBuilder();
-        $queryBuilder->addFields($this->getFields($fields));
-        if ($searchArgs) {
-            $queryBuilder->setFilter($searchArgs);
-        }
-        if ($queryArgs) {
-            $queryBuilder->setQueryArgs($queryArgs);
-        }
-        $query = $queryBuilder->build();
-        $response = $this->sendRequest($query);
-        $articles = $response['articles'] ?? [];
-        $articles_list = $this->toArticlesList($fields, $articles);
-
-        if (!empty($response['total'])) {
-            $articles_list->addTotalArticlesCount($response['total']);
-        }
-        if (!empty($response['cursor'])) {
-            $articles_list->addPageCursor($response['cursor']);
-        }
-        return $articles_list;
+  public function loadAll(
+      ?ArticleQueryArgs $queryArgs,
+      ?ArticleSearchArgs $searchArgs,
+      array $fields = []
+  ): ArticlesList {
+      $queryBuilder = new ArticlesListQueryBuilder();
+      $queryBuilder->addFields($this->getFields($fields));
+    if ($searchArgs) {
+        $queryBuilder->setFilter($searchArgs);
     }
+    if ($queryArgs) {
+        $queryBuilder->setQueryArgs($queryArgs);
+    }
+      $query = $queryBuilder->build();
+      $response = $this->sendRequest($query);
+      $articles = $response['articles'] ?? [];
+      $articles_list = $this->toArticlesList($fields, $articles);
+
+    if (!empty($response['total'])) {
+        $articles_list->addTotalArticlesCount($response['total']);
+    }
+    if (!empty($response['cursor'])) {
+        $articles_list->addPageCursor($response['cursor']);
+    }
+      return $articles_list;
+  }
 
     /**
      * Parse response to get ArticlesList.
@@ -380,17 +379,16 @@ class ArticleLoader implements ArticleLoaderInterface
      * @return ArticlesList
      *   ArticlesList entity.
      */
-    private function toArticlesList(array $fields, array $data): ArticlesList
-    {
-        $articlesList = new ArticlesList();
-        foreach ($data as $article) {
-            $articleEntity = $this->toArticle($fields, $article);
-            if ($articleEntity instanceof Article) {
-                $articlesList->addArticle($articleEntity);
-            }
-        }
-
-        return $articlesList;
+  private function toArticlesList(array $fields, array $data): ArticlesList
+  {
+      $articlesList = new ArticlesList();
+    foreach ($data as $article) {
+        $articleEntity = $this->toArticle($fields, $article);
+      if ($articleEntity instanceof Article) {
+        $articlesList->addArticle($articleEntity);
+      }
     }
 
+      return $articlesList;
+  }
 }

--- a/src/core/Entity/Loader/ArticleLoaderInterface.php
+++ b/src/core/Entity/Loader/ArticleLoaderInterface.php
@@ -12,8 +12,8 @@ use PccPhpSdk\core\Entity\ArticlesList;
 /**
  * Article Loader Interface.
  */
-interface ArticleLoaderInterface {
-
+interface ArticleLoaderInterface
+{
   /**
    * ID identifier.
    */
@@ -29,11 +29,11 @@ interface ArticleLoaderInterface {
    * Load Article by ID.
    *
    * @param string $articleId
-   *   Article ID.
+   *   Article id.
    * @param array $fields
    *   The Article fields.
    * @param PublishingLevel $publishingLevel
-   *     The publishing Level.
+   *   The publishing Level.
    * @param ContentType|null $contentType
    *   The content type.
    * @param string|null $versionId
@@ -42,9 +42,15 @@ interface ArticleLoaderInterface {
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity or null.
    */
-  public function loadById(string $articleId, array $fields=[], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null, ?string $versionId = null): ?Article;
+  public function loadById(
+      string $articleId,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?ContentType $contentType = null,
+      ?string $versionId = null
+  ): ?Article;
 
-  
+
   /**
    * Load Article by slug.
    *
@@ -60,7 +66,12 @@ interface ArticleLoaderInterface {
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article or null.
    */
-  public function loadBySlug(string $slug, array $fields=[], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?string $versionId = null): ?Article;
+  public function loadBySlug(
+      string $slug,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?string $versionId = null
+  ): ?Article;
 
   /**
    * Load All Articles based on Query and Search args.
@@ -75,6 +86,9 @@ interface ArticleLoaderInterface {
    * @return \PccPhpSdk\core\Entity\ArticlesList
    *   ArticlesList containing all articles matching the criterion.
    */
-  public function loadAll(?ArticleQueryArgs $queryArgs, ?ArticleSearchArgs $searchArgs, array $fields = []): ArticlesList;
-
+  public function loadAll(
+      ?ArticleQueryArgs $queryArgs,
+      ?ArticleSearchArgs $searchArgs,
+      array $fields = []
+  ): ArticlesList;
 }

--- a/src/core/Entity/Loader/ArticleLoaderInterface.php
+++ b/src/core/Entity/Loader/ArticleLoaderInterface.php
@@ -14,34 +14,34 @@ use PccPhpSdk\core\Entity\ArticlesList;
  */
 interface ArticleLoaderInterface
 {
-  /**
-   * ID identifier.
-   */
+    /**
+     * ID identifier.
+     */
   public const ID = 'id';
 
-  /**
-   * Slug identifier.
-   */
+    /**
+     * Slug identifier.
+     */
   public const SLUG = 'slug';
 
 
-  /**
-   * Load Article by ID.
-   *
-   * @param string $articleId
-   *   Article id.
-   * @param array $fields
-   *   The Article fields.
-   * @param PublishingLevel $publishingLevel
-   *   The publishing Level.
-   * @param ContentType|null $contentType
-   *   The content type.
-   * @param string|null $versionId
-   *   The version ID.
-   *
-   * @return \PccPhpSdk\core\Entity\Article|null
-   *   Article Entity or null.
-   */
+    /**
+     * Load Article by ID.
+     *
+     * @param string $articleId
+     *   Article id.
+     * @param array $fields
+     *   The Article fields.
+     * @param PublishingLevel $publishingLevel
+     *   The publishing Level.
+     * @param ContentType|null $contentType
+     *   The content type.
+     * @param string|null $versionId
+     *   The version ID.
+     *
+     * @return \PccPhpSdk\core\Entity\Article|null
+     *   Article Entity or null.
+     */
   public function loadById(
       string $articleId,
       array $fields = [],
@@ -51,21 +51,21 @@ interface ArticleLoaderInterface
   ): ?Article;
 
 
-  /**
-   * Load Article by slug.
-   *
-   * @param string $slug
-   *   Article slug.
-   * @param array $fields
-   *   The Article fields.
-   * @param PublishingLevel $publishingLevel
-   *     The publishing Level.
-   * @param string|null $versionId
-   *   The version ID.
-   *
-   * @return \PccPhpSdk\core\Entity\Article|null
-   *   Article or null.
-   */
+    /**
+     * Load Article by slug.
+     *
+     * @param string $slug
+     *   Article slug.
+     * @param array $fields
+     *   The Article fields.
+     * @param PublishingLevel $publishingLevel
+     *     The publishing Level.
+     * @param string|null $versionId
+     *   The version ID.
+     *
+     * @return \PccPhpSdk\core\Entity\Article|null
+     *   Article or null.
+     */
   public function loadBySlug(
       string $slug,
       array $fields = [],
@@ -73,19 +73,19 @@ interface ArticleLoaderInterface
       ?string $versionId = null
   ): ?Article;
 
-  /**
-   * Load All Articles based on Query and Search args.
-   *
-   * @param \PccPhpSdk\api\Query\ArticleQueryArgs|null $queryArgs
-   *   Article Query Args.
-   * @param \PccPhpSdk\api\Query\ArticleSearchArgs|null $searchArgs
-   *   Article Search Args.
-   * @param array $fields
-   *   The Article fields.
-   *
-   * @return \PccPhpSdk\core\Entity\ArticlesList
-   *   ArticlesList containing all articles matching the criterion.
-   */
+    /**
+     * Load All Articles based on Query and Search args.
+     *
+     * @param \PccPhpSdk\api\Query\ArticleQueryArgs|null $queryArgs
+     *   Article Query Args.
+     * @param \PccPhpSdk\api\Query\ArticleSearchArgs|null $searchArgs
+     *   Article Search Args.
+     * @param array $fields
+     *   The Article fields.
+     *
+     * @return \PccPhpSdk\core\Entity\ArticlesList
+     *   ArticlesList containing all articles matching the criterion.
+     */
   public function loadAll(
       ?ArticleQueryArgs $queryArgs,
       ?ArticleSearchArgs $searchArgs,

--- a/src/core/PccClient.php
+++ b/src/core/PccClient.php
@@ -10,8 +10,8 @@ use PccPhpSdk\Exception\PccClientException;
 /**
  * PccClient Class.
  */
-class PccClient {
-
+class PccClient
+{
   /**
    * PCC Token Header.
    */
@@ -27,7 +27,8 @@ class PccClient {
   /**
    * @param PccClientConfig $clientConfig
    */
-  public function __construct(PccClientConfig $clientConfig) {
+  public function __construct(PccClientConfig $clientConfig)
+  {
     $this->clientConfig = $clientConfig;
   }
 
@@ -42,7 +43,8 @@ class PccClient {
    *
    * @throws \PccPhpSdk\Exception\PccClientException
    */
-  public function executeQuery(QueryInterface $query): mixed {
+  public function executeQuery(QueryInterface $query): mixed
+  {
     return $this->sendRequest($query->toRequestBody());
   }
 
@@ -57,15 +59,15 @@ class PccClient {
    *
    * @throws \PccPhpSdk\Exception\PccClientException
    */
-  public function sendRequest(bool|string $body): mixed {
+  public function sendRequest(bool|string $body): mixed
+  {
     $client = new Client();
     $headers = $this->getHeaders();
     $request = new Request('POST', $this->getUrl(), $headers, $body);
     try {
       $response = $client->sendAsync($request)->wait();
-    }
-    catch (\Exception $e) {
-      throw new PccClientException($e->getMessage(), $request, NULL, $e);
+    } catch (\Exception $e) {
+      throw new PccClientException($e->getMessage(), $request, null, $e);
     }
     return $response->getBody()->getContents();
   }
@@ -76,7 +78,8 @@ class PccClient {
    * @return array
    *   Array of headers and the corresponding values.
    */
-  private function getHeaders(): array {
+  private function getHeaders(): array
+  {
     return [
       'Content-Type' => 'application/json',
       self::PCC_TOKEN_HEADER => $this->clientConfig->getSiteToken(),
@@ -89,8 +92,8 @@ class PccClient {
    * @return string
    *   PCC API URL string.
    */
-  private function getUrl(): string {
+  private function getUrl(): string
+  {
     return $this->clientConfig->getPccHost() . 'sites/' . $this->clientConfig->getSiteId() . '/query';
   }
-
 }

--- a/src/core/PccClientConfig.php
+++ b/src/core/PccClientConfig.php
@@ -5,8 +5,8 @@ namespace PccPhpSdk\core;
 /**
  * Pcc Client Configurations.
  */
-class PccClientConfig {
-
+class PccClientConfig
+{
   /**
    * Default PCC Host URL.
    */
@@ -52,7 +52,8 @@ class PccClientConfig {
    * @param string|null $pccGrant
    *   Pcc Grant.
    */
-  public function __construct(string $siteId, string $siteToken, string $pccHost = null, string $pccGrant = null) {
+  public function __construct(string $siteId, string $siteToken, string $pccHost = null, string $pccGrant = null)
+  {
     $this->siteId = $siteId;
     $this->siteToken = $siteToken;
     $this->pccHost = $pccHost ?? self::PCC_HOST_DEFAULT;
@@ -65,7 +66,8 @@ class PccClientConfig {
    * @return string
    *   PCC Host URL string.
    */
-  public function getPccHost() : string {
+  public function getPccHost(): string
+  {
     return $this->pccHost;
   }
 
@@ -75,7 +77,8 @@ class PccClientConfig {
    * @return string
    *   PCC Site ID.
    */
-  public function getSiteId() : string {
+  public function getSiteId(): string
+  {
     return $this->siteId;
   }
 
@@ -85,7 +88,8 @@ class PccClientConfig {
    * @return string
    *   PCC Site Token
    */
-  public function getSiteToken() : string {
+  public function getSiteToken(): string
+  {
     return !empty($this->siteToken) ? $this->siteToken : $this->getPCCGrant();
   }
 
@@ -95,10 +99,11 @@ class PccClientConfig {
    * @return string
    *   PCC grant string.
    */
-  private function getPCCGrant() : string {
+  private function getPCCGrant(): string
+  {
     $pccGrant = $this->pccGrant;
     if (!empty($pccGrant) && !str_contains('pcc_grant', $pccGrant)) {
-     $pccGrant = "pcc_grant $pccGrant";
+      $pccGrant = "pcc_grant $pccGrant";
     }
 
     return $pccGrant ?? '';

--- a/src/core/Query/Builder/Article/ArticleBaseQueryBuilder.php
+++ b/src/core/Query/Builder/Article/ArticleBaseQueryBuilder.php
@@ -7,8 +7,8 @@ use PccPhpSdk\core\Query\Builder\QueryBuilderInterface;
 /**
  * Abstract class for Article Entity Query Builder.
  */
-abstract class ArticleBaseQueryBuilder implements QueryBuilderInterface {
-
+abstract class ArticleBaseQueryBuilder implements QueryBuilderInterface
+{
   /**
    * Fields to include.
    *
@@ -19,7 +19,8 @@ abstract class ArticleBaseQueryBuilder implements QueryBuilderInterface {
   /**
    * {@inheritDoc}
    */
-  public function addField(string $fieldName): QueryBuilderInterface {
+  public function addField(string $fieldName): QueryBuilderInterface
+  {
     $this->fields[] = $fieldName;
     return $this;
   }
@@ -27,9 +28,9 @@ abstract class ArticleBaseQueryBuilder implements QueryBuilderInterface {
   /**
    * {@inheritDoc}
    */
-  public function addFields(array $fieldNames): QueryBuilderInterface {
+  public function addFields(array $fieldNames): QueryBuilderInterface
+  {
     $this->fields = array_merge($this->fields, $fieldNames);
     return $this;
   }
-
 }

--- a/src/core/Query/Builder/Article/ArticleFilterInput.php
+++ b/src/core/Query/Builder/Article/ArticleFilterInput.php
@@ -11,8 +11,8 @@ use PccPhpSdk\api\Query\Enums\PublishStatus;
  *
  * @package PccPhpSdk\core\Query\Builder\Article
  */
-class ArticleFilterInput {
-
+class ArticleFilterInput
+{
   /**
    * @var string $bodyContains
    *   The string to search for within the body of articles.
@@ -54,7 +54,12 @@ class ArticleFilterInput {
    * @param PublishStatus $publishStatus
    *   The publishing status to filter articles by.
    */
-  public function __construct(string $bodyContains, string $tagContains, string $titleContains, PublishStatus $publishStatus) {
+  public function __construct(
+      string $bodyContains,
+      string $tagContains,
+      string $titleContains,
+      PublishStatus $publishStatus
+  ) {
     $this->bodyContains = $bodyContains;
     $this->tagContains = $tagContains;
     $this->titleContains = $titleContains;
@@ -67,7 +72,8 @@ class ArticleFilterInput {
    * @param string $bodyContains
    *   The string to search for within the body of articles.
    */
-  public function setBodyContains(string $bodyContains): void {
+  public function setBodyContains(string $bodyContains): void
+  {
     $this->bodyContains = $bodyContains;
   }
 
@@ -77,7 +83,8 @@ class ArticleFilterInput {
    * @param string $tagContains
    *   The string to search for within the tags of articles.
    */
-  public function setTagContains(string $tagContains): void {
+  public function setTagContains(string $tagContains): void
+  {
     $this->tagContains = $tagContains;
   }
 
@@ -87,7 +94,8 @@ class ArticleFilterInput {
    * @param string $titleContains
    *   The string to search for within the title of articles.
    */
-  public function setTitleContains(string $titleContains): void {
+  public function setTitleContains(string $titleContains): void
+  {
     $this->titleContains = $titleContains;
   }
 
@@ -97,7 +105,8 @@ class ArticleFilterInput {
    * @param PublishStatus $publishStatus
    *   The publishing status to filter articles by.
    */
-  public function setPublishStatus(PublishStatus $publishStatus): void {
+  public function setPublishStatus(PublishStatus $publishStatus): void
+  {
     $this->publishStatus = $publishStatus;
   }
 
@@ -107,7 +116,8 @@ class ArticleFilterInput {
    * @return string
    *   The string to search for within the body of articles.
    */
-  public function getBodyContains(): string {
+  public function getBodyContains(): string
+  {
     return $this->bodyContains;
   }
 
@@ -117,7 +127,8 @@ class ArticleFilterInput {
    * @return string
    *   The string to search for within the tags of articles.
    */
-  public function getTagContains(): string {
+  public function getTagContains(): string
+  {
     return $this->tagContains;
   }
 
@@ -127,7 +138,8 @@ class ArticleFilterInput {
    * @return string
    *   The string to search for within the title of articles.
    */
-  public function getTitleContains(): string {
+  public function getTitleContains(): string
+  {
     return $this->titleContains;
   }
 
@@ -137,9 +149,8 @@ class ArticleFilterInput {
    * @return PublishStatus
    *   The publishing status to filter articles by.
    */
-  public function getPublishStatus(): PublishStatus {
+  public function getPublishStatus(): PublishStatus
+  {
     return $this->publishStatus;
   }
-
 }
-

--- a/src/core/Query/Builder/Article/ArticleQueryBuilder.php
+++ b/src/core/Query/Builder/Article/ArticleQueryBuilder.php
@@ -21,14 +21,14 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder
    *
    * @var string|null
    */
-  private ?string $id = null;
+  private ?string $articleId = null;
 
   /**
    * Article Slug to filter.
    *
    * @var string|null
    */
-  private ?string $slug = null;
+  private ?string $articleSlug = null;
 
   /**
    * Publishing Level.
@@ -54,15 +54,15 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder
   /**
    * Add ID for filter in the query.
    *
-   * @param string $id
+   * @param string $articleId
    *   ID value.
    *
    * @return \PccPhpSdk\core\Query\Builder\QueryBuilderInterface
    *   Returns self.
    */
-  public function filterById(string $id): QueryBuilderInterface
+  public function filterById(string $articleId): QueryBuilderInterface
   {
-    $this->id = $id;
+    $this->articleId = $articleId;
     return $this;
   }
 
@@ -71,15 +71,15 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder
    *
    * If ID filter already present, that will take precedence.
    *
-   * @param string $slug
+   * @param string $articleSlug
    *   Slug Value.
    *
    * @return \PccPhpSdk\core\Query\Builder\QueryBuilderInterface
    *   Returns self.
    */
-  public function filterBySlug(string $slug): QueryBuilderInterface
+  public function filterBySlug(string $articleSlug): QueryBuilderInterface
   {
-    $this->slug = $slug;
+    $this->articleSlug = $articleSlug;
     return $this;
   }
 
@@ -169,10 +169,10 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder
   private function getVariableVal(): \ArrayObject
   {
     $value = [];
-    if ($this->id !== null) {
-      $value[ArticleLoaderInterface::ID] = $this->id;
-    } elseif ($this->slug !== null) {
-      $value[ArticleLoaderInterface::SLUG] = $this->slug;
+    if ($this->articleId !== null) {
+      $value[ArticleLoaderInterface::ID] = $this->articleId;
+    } elseif ($this->articleSlug !== null) {
+      $value[ArticleLoaderInterface::SLUG] = $this->articleSlug;
     }
     $value[Variables::PUBLISHING_LEVEL] = $this->publishing_level;
     if ($this->version_id !== null) {
@@ -191,9 +191,9 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder
   private function getVariableDef(): ?array
   {
     $variable = null;
-    if ($this->id !== null) {
+    if ($this->articleId !== null) {
       $variable = [ArticleLoaderInterface::ID => $this->buildIdVariableDef()];
-    } elseif ($this->slug !== null) {
+    } elseif ($this->articleSlug !== null) {
       $variable = [ArticleLoaderInterface::SLUG => $this->buildSlugVariableDef()];
     }
     $variable[Variables::PUBLISHING_LEVEL] = $this->buildPublishingLevelVariableDef();

--- a/src/core/Query/Builder/Article/ArticleQueryBuilder.php
+++ b/src/core/Query/Builder/Article/ArticleQueryBuilder.php
@@ -14,20 +14,21 @@ use PccPhpSdk\core\Query\QueryInterface;
 /**
  * Article Query Builder to get single Article.
  */
-class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
+class ArticleQueryBuilder extends ArticleBaseQueryBuilder
+{
   /**
    * Article ID to filter.
    *
    * @var string|null
    */
-  private ?string $id = NULL;
+  private ?string $id = null;
 
   /**
    * Article Slug to filter.
    *
    * @var string|null
    */
-  private ?string $slug = NULL;
+  private ?string $slug = null;
 
   /**
    * Publishing Level.
@@ -59,7 +60,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return \PccPhpSdk\core\Query\Builder\QueryBuilderInterface
    *   Returns self.
    */
-  public function filterById(string $id): QueryBuilderInterface {
+  public function filterById(string $id): QueryBuilderInterface
+  {
     $this->id = $id;
     return $this;
   }
@@ -75,7 +77,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return \PccPhpSdk\core\Query\Builder\QueryBuilderInterface
    *   Returns self.
    */
-  public function filterBySlug(string $slug): QueryBuilderInterface {
+  public function filterBySlug(string $slug): QueryBuilderInterface
+  {
     $this->slug = $slug;
     return $this;
   }
@@ -89,7 +92,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return QueryBuilderInterface
    *   Return self.
    */
-  public function setPublishingLevel(?PublishingLevel $publishing_level): QueryBuilderInterface {
+  public function setPublishingLevel(?PublishingLevel $publishing_level): QueryBuilderInterface
+  {
     $this->publishing_level = empty($publishing_level) ? PublishingLevel::PRODUCTION : $publishing_level;
     return $this;
   }
@@ -103,7 +107,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return QueryBuilderInterface
    *   Return self.
    */
-  public function setContentType(?ContentType $content_type): QueryBuilderInterface {
+  public function setContentType(?ContentType $content_type): QueryBuilderInterface
+  {
     $this->content_type = empty($content_type) ? ContentType::TEXT_MARKDOWN : $content_type;
     return $this;
   }
@@ -117,7 +122,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return QueryBuilderInterface
    *   Return self.
    */
-  public function setVersionId(?string $version_id): QueryBuilderInterface {
+  public function setVersionId(?string $version_id): QueryBuilderInterface
+  {
     $this->version_id = $version_id;
     return $this;
   }
@@ -125,7 +131,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
   /**
    * {@inheritDoc}
    */
-  public function build(): QueryInterface {
+  public function build(): QueryInterface
+  {
     $query = new Query('article', $this->getQueryArgs());
     $query->use(...$this->fields);
     $parsedQuery = $query->root()->parse();
@@ -139,7 +146,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return array
    *   Returns Query Args.
    */
-  private function getQueryArgs(): array {
+  private function getQueryArgs(): array
+  {
     $content_type = $this->content_type->value;
     $args = [
       Variables::CONTENT_TYPE => Variables::getVariableDefinition(Variables::CONTENT_TYPE, $content_type),
@@ -158,12 +166,12 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return \ArrayObject
    *   Returns Variable mapped values.
    */
-  private function getVariableVal(): \ArrayObject {
+  private function getVariableVal(): \ArrayObject
+  {
     $value = [];
-    if ($this->id !== NULL) {
+    if ($this->id !== null) {
       $value[ArticleLoaderInterface::ID] = $this->id;
-    }
-    elseif ($this->slug !== NULL) {
+    } elseif ($this->slug !== null) {
       $value[ArticleLoaderInterface::SLUG] = $this->slug;
     }
     $value[Variables::PUBLISHING_LEVEL] = $this->publishing_level;
@@ -180,12 +188,12 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return \GraphQL\Entities\Variable[]|null
    *   Return ID or Slug variable definition or null.
    */
-  private function getVariableDef(): ?array {
-    $variable = NULL;
-    if ($this->id !== NULL) {
+  private function getVariableDef(): ?array
+  {
+    $variable = null;
+    if ($this->id !== null) {
       $variable = [ArticleLoaderInterface::ID => $this->buildIdVariableDef()];
-    }
-    elseif ($this->slug !== NULL) {
+    } elseif ($this->slug !== null) {
       $variable = [ArticleLoaderInterface::SLUG => $this->buildSlugVariableDef()];
     }
     $variable[Variables::PUBLISHING_LEVEL] = $this->buildPublishingLevelVariableDef();
@@ -202,7 +210,8 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return \GraphQL\Entities\Variable
    *   Return Variable Definition.
    */
-  private function buildIdVariableDef(): Variable {
+  private function buildIdVariableDef(): Variable
+  {
     return new Variable(ArticleLoaderInterface::ID, 'String');
   }
 
@@ -212,11 +221,13 @@ class ArticleQueryBuilder extends ArticleBaseQueryBuilder {
    * @return \GraphQL\Entities\Variable
    *   Return Variable Definition.
    */
-  private function buildSlugVariableDef(): Variable {
+  private function buildSlugVariableDef(): Variable
+  {
     return new Variable(ArticleLoaderInterface::SLUG, 'String');
   }
 
-  private function buildPublishingLevelVariableDef(): Variable {
+  private function buildPublishingLevelVariableDef(): Variable
+  {
     return Variables::getVariableDefinition(Variables::PUBLISHING_LEVEL);
   }
 }

--- a/src/core/Query/Builder/Article/ArticlesListQueryBuilder.php
+++ b/src/core/Query/Builder/Article/ArticlesListQueryBuilder.php
@@ -16,8 +16,8 @@ use PccPhpSdk\core\Query\QueryInterface;
 /**
  * Articles List Query Builder to get multiple articles.
  */
-class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
-
+class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder
+{
   /**
    * Filter inputs for querying articles.
    *
@@ -68,7 +68,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return QueryInterface
    *   The built query.
    */
-  public function build(): QueryInterface {
+  public function build(): QueryInterface
+  {
     $query = new Query('articles', $this->getQueryArgs());
     $query->use(...$this->fields);
     $parsedQuery = $query->root()->parse();
@@ -85,12 +86,13 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return $this
    *   Returns self for method chaining.
    */
-  public function setFilter(ArticleSearchArgs $searchArgs): ArticlesListQueryBuilder {
+  public function setFilter(ArticleSearchArgs $searchArgs): ArticlesListQueryBuilder
+  {
     $this->filter = new ArticleFilterInput(
-      $searchArgs->bodyContains,
-      $searchArgs->tagContains,
-      $searchArgs->titleContains,
-      $searchArgs->publishStatus
+        $searchArgs->bodyContains,
+        $searchArgs->tagContains,
+        $searchArgs->titleContains,
+        $searchArgs->publishStatus
     );
     return $this;
   }
@@ -104,7 +106,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return $this
    *   Returns self.
    */
-  public function setQueryArgs(ArticleQueryArgs $queryArgs): ArticlesListQueryBuilder {
+  public function setQueryArgs(ArticleQueryArgs $queryArgs): ArticlesListQueryBuilder
+  {
     $this->contentType = $queryArgs->getContentType();
     $this->sortField = $queryArgs->getSortField();
     $this->sortOrder = $queryArgs->getSortOrder();
@@ -122,7 +125,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return $this
    *   Returns self for method chaining.
    */
-  public function setSortField(ArticleSortField $sortField): ArticlesListQueryBuilder {
+  public function setSortField(ArticleSortField $sortField): ArticlesListQueryBuilder
+  {
     $this->sortField = $sortField;
     return $this;
   }
@@ -136,7 +140,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return $this
    *   Returns self for method chaining.
    */
-  public function setSortOrder(ArticleSortOrder $sortOrder): ArticlesListQueryBuilder {
+  public function setSortOrder(ArticleSortOrder $sortOrder): ArticlesListQueryBuilder
+  {
     $this->sortOrder = $sortOrder;
     return $this;
   }
@@ -150,7 +155,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return $this
    *   Returns self for method chaining.
    */
-  public function setPageSize(int $pageSize): ArticlesListQueryBuilder {
+  public function setPageSize(int $pageSize): ArticlesListQueryBuilder
+  {
     $this->pageSize = $pageSize;
     return $this;
   }
@@ -164,7 +170,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return $this
    *   Returns self for method chaining.
    */
-  public function setPageIndex(int $pageIndex): ArticlesListQueryBuilder {
+  public function setPageIndex(int $pageIndex): ArticlesListQueryBuilder
+  {
     $this->pageIndex = $pageIndex;
     return $this;
   }
@@ -178,7 +185,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return $this
    *   Returns self for method chaining.
    */
-  public function setContentType(ContentType $contentType): ArticlesListQueryBuilder {
+  public function setContentType(ContentType $contentType): ArticlesListQueryBuilder
+  {
     $this->contentType = $contentType;
     return $this;
   }
@@ -189,7 +197,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return ArticleFilterInput|null
    *   Filter inputs for querying articles.
    */
-  public function getFilter(): ?ArticleFilterInput {
+  public function getFilter(): ?ArticleFilterInput
+  {
     return $this->filter;
   }
 
@@ -199,7 +208,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return ArticleSortField|null
    *   The sort field.
    */
-  public function getSortField(): ?ArticleSortField {
+  public function getSortField(): ?ArticleSortField
+  {
     return $this->sortField;
   }
 
@@ -209,7 +219,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return ArticleSortOrder|null
    *   The sort order.
    */
-  public function getSortOrder(): ?ArticleSortOrder {
+  public function getSortOrder(): ?ArticleSortOrder
+  {
     return $this->sortOrder;
   }
 
@@ -219,7 +230,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return int|null
    *   The number of articles per page.
    */
-  public function getPageSize(): ?int {
+  public function getPageSize(): ?int
+  {
     return $this->pageSize;
   }
 
@@ -229,7 +241,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return int|null
    *   The page index.
    */
-  public function getPageIndex(): ?int {
+  public function getPageIndex(): ?int
+  {
     return $this->pageIndex;
   }
 
@@ -239,7 +252,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return ContentType
    *   The content type.
    */
-  public function getContentType(): ContentType {
+  public function getContentType(): ContentType
+  {
     return $this->contentType;
   }
 
@@ -249,7 +263,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return array
    *   Returns query arguments.
    */
-  private function getQueryArgs(): array {
+  private function getQueryArgs(): array
+  {
     $args = [
       'contentType' => $this->contentType,
     ];
@@ -267,7 +282,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return Variable[]|null
    *   Return filter variable definitions or null.
    */
-  private function getVariableDef(): ?array {
+  private function getVariableDef(): ?array
+  {
     $variables = [];
 
     if ($this->filter !== null) {
@@ -298,7 +314,8 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
    * @return ArrayObject
    *   Returns variable mapped values.
    */
-  private function getVariableVal(): ArrayObject {
+  private function getVariableVal(): ArrayObject
+  {
     $value = [];
     if ($this->filter !== null) {
       $value[Variables::FILTER] = [
@@ -326,5 +343,4 @@ class ArticlesListQueryBuilder extends ArticleBaseQueryBuilder {
 
     return new ArrayObject($value);
   }
-
 }

--- a/src/core/Query/Builder/Article/Variables.php
+++ b/src/core/Query/Builder/Article/Variables.php
@@ -9,8 +9,8 @@ use GraphQL\Entities\Variable;
  *
  * Defines constants and methods to handle variable definitions for GraphQL queries.
  */
-class Variables {
-
+class Variables
+{
   public const FILTER = 'filter';
   public const PAGE_SIZE = 'pageSize';
   public const SORT_FIELD = 'sortBy';
@@ -32,35 +32,35 @@ class Variables {
    * @return \GraphQL\Entities\Variable|null
    *   Returns the variable definition or null if the field name is invalid.
    */
-  public static function getVariableDefinition(string $fieldName, string $defaultValue = ''): ?Variable {
+  public static function getVariableDefinition(string $fieldName, string $defaultValue = ''): ?Variable
+  {
     switch ($fieldName) {
       case self::FILTER:
-        return new Variable(self::FILTER, 'ArticleFilterInput');
+          return new Variable(self::FILTER, 'ArticleFilterInput');
 
       case self::PAGE_SIZE:
-        return new Variable(self::PAGE_SIZE, 'Int');
+          return new Variable(self::PAGE_SIZE, 'Int');
 
       case self::SORT_FIELD:
-        return new Variable(self::SORT_FIELD, 'ArticleSortField');
+          return new Variable(self::SORT_FIELD, 'ArticleSortField');
 
       case self::SORT_ORDER:
-        return new Variable(self::SORT_ORDER, 'SortOrder');
+          return new Variable(self::SORT_ORDER, 'SortOrder');
 
       case self::PAGE_INDEX:
-        return new Variable(self::PAGE_INDEX, 'Float');
+          return new Variable(self::PAGE_INDEX, 'Float');
 
       case self::CONTENT_TYPE:
-        return new Variable(self::CONTENT_TYPE, 'ContentType', $defaultValue);
+          return new Variable(self::CONTENT_TYPE, 'ContentType', $defaultValue);
 
       case self::PUBLISHING_LEVEL:
-        return new Variable(self::PUBLISHING_LEVEL, 'PublishingLevel');
+          return new Variable(self::PUBLISHING_LEVEL, 'PublishingLevel');
 
       case self::VERSION_ID:
-        return new Variable(self::VERSION_ID, 'String');
+          return new Variable(self::VERSION_ID, 'String');
 
       default:
-        return NULL;
+          return null;
     }
   }
-
 }

--- a/src/core/Query/Builder/QueryBuilderInterface.php
+++ b/src/core/Query/Builder/QueryBuilderInterface.php
@@ -10,8 +10,8 @@ use PccPhpSdk\core\Query\QueryInterface;
  * To build Query
  * @see QueryInterface
  */
-interface QueryBuilderInterface {
-
+interface QueryBuilderInterface
+{
   /**
    * Add field.
    *
@@ -21,7 +21,7 @@ interface QueryBuilderInterface {
    * @return QueryBuilderInterface
    *   Returns the QueryBuilderInterface for chaining.
    */
-  public function addField(string $fieldName) : QueryBuilderInterface;
+  public function addField(string $fieldName): QueryBuilderInterface;
 
   /**
    * Add fields.
@@ -32,7 +32,7 @@ interface QueryBuilderInterface {
    * @return QueryBuilderInterface
    *   Returns the QueryBuilderInterface for chaining.
    */
-  public function addFields(array $fieldNames) : QueryBuilderInterface;
+  public function addFields(array $fieldNames): QueryBuilderInterface;
 
   /**
    * Build Query.
@@ -41,5 +41,4 @@ interface QueryBuilderInterface {
    *   Returns Instance of QueryInterface.
    */
   public function build(): QueryInterface;
-
 }

--- a/src/core/Query/GraphQLQuery.php
+++ b/src/core/Query/GraphQLQuery.php
@@ -5,8 +5,8 @@ namespace PccPhpSdk\core\Query;
 /**
  * GraphQL Query class.
  */
-class GraphQLQuery implements QueryInterface {
-
+class GraphQLQuery implements QueryInterface
+{
   /**
    * Query string.
    *
@@ -21,7 +21,8 @@ class GraphQLQuery implements QueryInterface {
    */
   private \ArrayObject $variables;
 
-  public function __construct(string $query, \ArrayObject $variables = new \ArrayObject()) {
+  public function __construct(string $query, \ArrayObject $variables = new \ArrayObject())
+  {
     $this->query = $query;
     $this->variables = $variables;
   }
@@ -29,7 +30,8 @@ class GraphQLQuery implements QueryInterface {
   /**
    * {@inheritDoc}
    */
-  public function toRequestBody(): string {
+  public function toRequestBody(): string
+  {
     $data = [
       'query' => $this->query,
       'variables' => $this->variables,
@@ -46,7 +48,8 @@ class GraphQLQuery implements QueryInterface {
    * @return void
    *   Returns void.
    */
-  public function setQuery(string $query): void {
+  public function setQuery(string $query): void
+  {
     $this->query = $query;
   }
 
@@ -59,8 +62,8 @@ class GraphQLQuery implements QueryInterface {
    * @return void
    *   Returns void.
    */
-  public function setVariables(array $variables): void {
+  public function setVariables(array $variables): void
+  {
     $this->variables = new \ArrayObject($variables);
   }
-
 }

--- a/src/core/Query/QueryInterface.php
+++ b/src/core/Query/QueryInterface.php
@@ -7,8 +7,8 @@ use PccPhpSdk\Enum\EntityType;
 /**
  * Query Interface to build JSON encoded query string for the payload of API request.
  */
-interface QueryInterface {
-
+interface QueryInterface
+{
   public function setVariables(array $variables);
 
   /**
@@ -18,5 +18,4 @@ interface QueryInterface {
    *   JSON encoded query string.
    */
   public function toRequestBody(): string;
-
 }

--- a/src/core/Services/ArticlesManager.php
+++ b/src/core/Services/ArticlesManager.php
@@ -57,7 +57,7 @@ class ArticlesManager
   /**
    * Get Article by ID.
    *
-   * @param string $id
+   * @param string $articleId
    *   Article ID.
    * @param array $fields
    *   The Article fields.
@@ -70,9 +70,11 @@ class ArticlesManager
    *
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity.
+   *
+   * @SuppressWarnings(PHPMD.UnusedFormalParameter)
    */
   public function getArticleById(
-      string $id,
+      string $articleId,
       array $fields = [],
       PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
       ?ContentType $contentType = null,
@@ -84,7 +86,7 @@ class ArticlesManager
   /**
    * Get Article by Slug.
    *
-   * @param string $slug
+   * @param string $articleSlug
    *   Article slug.
    * @param array $fields
    *   The Article fields.
@@ -95,9 +97,11 @@ class ArticlesManager
    *
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity.
+   *
+   * @SuppressWarnings(PHPMD.UnusedFormalParameter)
    */
   public function getArticleBySlug(
-      string $slug,
+      string $articleSlug,
       array $fields = [],
       PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
       ?string $versionId = null

--- a/src/core/Services/ArticlesManager.php
+++ b/src/core/Services/ArticlesManager.php
@@ -15,8 +15,8 @@ use PccPhpSdk\core\PccClient;
 /**
  * Articles Manager service.
  */
-class ArticlesManager {
-
+class ArticlesManager
+{
   /**
    * Article Loader.
    *
@@ -30,7 +30,8 @@ class ArticlesManager {
    * @param \PccPhpSdk\core\PccClient $pccClient
    *   Preconfigured PccClient.
    */
-  public function __construct(PccClient $pccClient) {
+  public function __construct(PccClient $pccClient)
+  {
     $this->articleLoader = new ArticleLoader($pccClient);
   }
 
@@ -45,7 +46,11 @@ class ArticlesManager {
    * @return \PccPhpSdk\core\Entity\ArticlesList
    *   ArticlesList containing matching articles.
    */
-  public function getArticles(?ArticleQueryArgs $queryArgs = NULL, ?ArticleSearchArgs $searchArgs = NULL, array $fields = []): ArticlesList {
+  public function getArticles(
+      ?ArticleQueryArgs $queryArgs = null,
+      ?ArticleSearchArgs $searchArgs = null,
+      array $fields = []
+  ): ArticlesList {
     return $this->articleLoader->loadAll($queryArgs, $searchArgs, $fields);
   }
 
@@ -66,8 +71,14 @@ class ArticlesManager {
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity.
    */
-  public function getArticleById(string $id, array $fields=[], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?ContentType $contentType = null, ?string $versionId = null): ?Article {
-	  return $this->articleLoader->loadById(...func_get_args());
+  public function getArticleById(
+      string $id,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?ContentType $contentType = null,
+      ?string $versionId = null
+  ): ?Article {
+    return $this->articleLoader->loadById(...func_get_args());
   }
 
   /**
@@ -85,8 +96,12 @@ class ArticlesManager {
    * @return \PccPhpSdk\core\Entity\Article|null
    *   Article Entity.
    */
-  public function getArticleBySlug(string $slug, array $fields=[], PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION, ?string $versionId = null): ?Article {
+  public function getArticleBySlug(
+      string $slug,
+      array $fields = [],
+      PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION,
+      ?string $versionId = null
+  ): ?Article {
     return $this->articleLoader->loadBySlug(...func_get_args());
   }
-
 }


### PR DESCRIPTION
# Overview
Contains no functional changes, only fixes formatting issues that cause Codacy static analysis to report errors on unrelated changes. 

Leaves complexity warnings so this PR doesn't contain any functional changes, also shouldn't be much of a problem since they won't be reported as new changes on unrelated change PRs.

# Changes
- Fixes typo in declaration of `squizlabs/php_codesniffer` in the composer.json that was causing local project installs to not work
- Adds missing code standard files, make indent level 2 to match existing files
- Run auto-fixer to format files, fixed long line warnings