### PR TITLE
Fix TypeError when node attrs contain array values in createElement

### DIFF
--- a/src/core/Entity/Loader/ArticleLoader.php
+++ b/src/core/Entity/Loader/ArticleLoader.php
@@ -284,7 +284,7 @@ class ArticleLoader implements ArticleLoaderInterface
       $element = '<' . $tag;
 
     foreach ($attrs as $key => $value) {
-        $element .= ' ' . $key . '="' . htmlspecialchars($value) . '"';
+        $element .= ' ' . $key . '="' . htmlspecialchars(is_array($value) ? json_encode($value) : (string) $value) . '"';
     }
 
       $style_string = '';

--- a/src/core/Entity/Loader/ArticleLoader.php
+++ b/src/core/Entity/Loader/ArticleLoader.php
@@ -284,7 +284,8 @@ class ArticleLoader implements ArticleLoaderInterface
       $element = '<' . $tag;
 
     foreach ($attrs as $key => $value) {
-        $element .= ' ' . $key . '="' . htmlspecialchars(is_array($value) ? json_encode($value) : (string) $value) . '"';
+        $attrValue = is_array($value) ? json_encode($value) : (string) $value;
+        $element .= ' ' . $key . '="' . htmlspecialchars($attrValue) . '"';
     }
 
       $style_string = '';


### PR DESCRIPTION
## Problem

`ArticleLoader::createElement()` iterates over node attrs and passes each value directly to `htmlspecialchars()`. When a node's attr value is a nested array (e.g. a component data object in `TREE_PANTHEON_V2` content), PHP throws a fatal error:

```
TypeError: htmlspecialchars(): Argument #1 ($string) must be of type string, array given
in ArticleLoader.php on line 287
```

## Fix

JSON-encode array values before passing to `htmlspecialchars()`, so the function always receives a string. Non-array values are cast to string as a defensive measure.

```php
// Before
$element .= ' ' . $key . '="' . htmlspecialchars($value) . '"';

// After
$element .= ' ' . $key . '="' . htmlspecialchars(is_array($value) ? json_encode($value) : (string) $value) . '"';
```

Backward-compatible: if all attr values are already strings, behavior is unchanged.